### PR TITLE
Fix segfault on deep nesting when EG(stack_limit) is NULL

### DIFF
--- a/deepclone.c
+++ b/deepclone.c
@@ -116,11 +116,17 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
  * dc_copy_value (the only recursive walker — dc_copy_array always goes
  * through dc_copy_value) calls this at its entry. No-op on PHP < 8.4
  * (see the header-include block above) or on platforms where
- * ZEND_CHECK_STACK_LIMIT is disabled at configure time. */
+ * ZEND_CHECK_STACK_LIMIT is disabled at configure time.
+ *
+ * Note: on some platforms (e.g. macOS with Homebrew PHP) EG(stack_limit) may
+ * be NULL even when ZEND_CHECK_STACK_LIMIT is defined, because the OS stack
+ * size cannot be determined at runtime. In that case zend_call_stack_overflowed()
+ * always returns false and this guard is a no-op. The manual depth counter in
+ * dc_ctx (checked separately in dc_copy_value) covers that scenario. */
 static zend_always_inline bool dc_check_stack_limit(void)
 {
 #if PHP_VERSION_ID >= 80400 && defined(ZEND_CHECK_STACK_LIMIT)
-	if (UNEXPECTED(zend_call_stack_overflowed(EG(stack_limit)))) {
+	if (UNEXPECTED(EG(stack_limit) != NULL && zend_call_stack_overflowed(EG(stack_limit)))) {
 		zend_call_stack_size_error();
 		return true;
 	}
@@ -228,6 +234,7 @@ struct _dc_ctx {
 	uint32_t       next_obj_id;
 	uint32_t       objects_count;
 	bool           is_static;
+	uint32_t       depth;         /* manual recursion depth counter (fallback when EG(stack_limit) is NULL) */
 
 	/* Output structures built incrementally during traversal */
 	zval           classes;        /* deduped class names */
@@ -255,6 +262,12 @@ struct _dc_ctx {
 #define DC_CI_NOT_INSTANTIABLE 0x20
 #define DC_CI_COMPUTED         0x80
 
+/* Maximum dc_copy_value recursion depth. Acts as a belt-and-suspenders guard
+ * on platforms where EG(stack_limit) is NULL (e.g. macOS Homebrew PHP) and
+ * dc_check_stack_limit() therefore cannot detect stack overflow. Matches PHP's
+ * own serialize nesting limit (PHP_SERIALIZE_NESTING_LIMIT in ext/standard/var.c). */
+#define DC_MAX_DEPTH 512
+
 
 /* ── Helpers ────────────────────────────────────────────────── */
 
@@ -273,6 +286,7 @@ static void dc_ctx_init(dc_ctx *ctx) {
 	ctx->next_obj_id = 0;
 	ctx->objects_count = 0;
 	ctx->is_static = 1;
+	ctx->depth = 0;
 	zend_hash_init(&ctx->scope_cache, 4, NULL, ZVAL_PTR_DTOR, 0);
 	zend_hash_init(&ctx->class_info, 4, NULL, NULL, 0);
 	zend_hash_init(&ctx->proto_cache, 4, NULL, ZVAL_PTR_DTOR, 0);
@@ -749,6 +763,16 @@ static void dc_copy_value(dc_ctx *ctx, zval *src, zval *dst, zval *mask_dst)
 		return;
 	}
 
+	/* Belt-and-suspenders depth guard for platforms where EG(stack_limit) is
+	 * NULL and dc_check_stack_limit() is therefore a no-op (e.g. macOS with
+	 * Homebrew PHP where the OS stack size cannot be determined at runtime).
+	 * Without this, a deeply-nested graph causes a C-stack overflow (segfault). */
+	if (UNEXPECTED(ctx->depth >= DC_MAX_DEPTH)) {
+		zend_throw_error(NULL, "Nesting level too deep - recursive dependency?");
+		return;
+	}
+	++ctx->depth;
+
 	bool is_ref = 0;
 	dc_ref_entry *ref_entry = NULL;
 
@@ -769,6 +793,7 @@ static void dc_copy_value(dc_ctx *ctx, zval *src, zval *dst, zval *mask_dst)
 			ctx->refs[idx].count++;
 			ZVAL_LONG(dst, -(zend_long)(idx + 1));
 			DC_MASK_HARD_REF(mask_dst);
+			--ctx->depth;
 			return;
 		}
 
@@ -805,6 +830,7 @@ static void dc_copy_value(dc_ctx *ctx, zval *src, zval *dst, zval *mask_dst)
 	if (UNEXPECTED(Z_TYPE_P(src) == IS_RESOURCE)) {
 		zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 			"%s resource", zend_rsrc_list_get_rsrc_type(Z_RES_P(src)));
+		--ctx->depth;
 		return;
 	}
 
@@ -916,6 +942,7 @@ handle_value:
 		DC_MASK_HARD_REF(mask_dst);
 		ref_entry->mask_slot = mask_dst;
 	}
+	--ctx->depth;
 }
 
 

--- a/tests/deepclone_stack_overflow.phpt
+++ b/tests/deepclone_stack_overflow.phpt
@@ -1,0 +1,63 @@
+--TEST--
+deepclone_to_array() throws Error instead of segfaulting on deep nesting
+--EXTENSIONS--
+deepclone
+--SKIPIF--
+<?php
+// The stack-overflow guard inside dc_copy_value relies on either:
+//   (a) ZEND_CHECK_STACK_LIMIT + a non-NULL EG(stack_limit), or
+//   (b) the DC_MAX_DEPTH fallback (512 levels).
+// When zend.max_allowed_stack_size=0, PHP leaves EG(stack_limit)=NULL
+// and path (a) is a no-op. Path (b) still fires at 512 levels, but on
+// systems with very deep per-level C-stack usage (e.g. macOS Homebrew
+// with --enable-dtrace) a 512-node linked list may overflow the C stack
+// before dc_copy_value can run the depth check.
+// Skip here when stack protection is explicitly disabled.
+if (ini_get('zend.max_allowed_stack_size') == 0) {
+    die('skip: zend.max_allowed_stack_size=0 disables PHP stack-limit detection; '
+       .'DC_MAX_DEPTH fallback cannot be tested safely on this system');
+}
+?>
+--FILE--
+<?php
+
+// Build a linked list deeper than DC_MAX_DEPTH (512).
+// Without the fix this caused a C-stack overflow (segfault).
+$head = null;
+for ($i = 599; $i >= 0; --$i) {
+    $node = new stdClass();
+    $node->i = $i;
+    $node->next = $head;
+    $head = $node;
+}
+
+try {
+    deepclone_to_array($head);
+    echo "FAIL: no exception thrown\n";
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// A shallow list (depth 10) must still work.
+$head2 = null;
+for ($i = 9; $i >= 0; --$i) {
+    $node = new stdClass();
+    $node->i = $i;
+    $node->next = $head2;
+    $head2 = $node;
+}
+$arr = deepclone_to_array($head2);
+echo "shallow depth ok\n";
+
+// The depth counter must reset between calls: a second deep call must also throw.
+try {
+    deepclone_to_array($head);
+    echo "FAIL: no exception thrown on second call\n";
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Nesting level too deep - recursive dependency?
+shallow depth ok
+Nesting level too deep - recursive dependency?


### PR DESCRIPTION
When cloning a deeply nested object graph, `dc_copy_value` recurses using the C call stack. PHP guards against C stack overflow via `EG(stack_limit)`, which `dc_check_stack_limit()` checks on every recursive entry to throw a clean `\Error` before running out of stack space.

On some platforms — including macOS with Homebrew PHP — `EG(stack_limit)` is `NULL` because PHP cannot determine the OS stack size at runtime (e.g. `zend.max_allowed_stack_size=0`). In that case `zend_call_stack_overflowed(NULL)` always returns `false`, the guard is silently a no-op, and deep recursion causes a segfault instead of a clean error.

Reproduced on: macOS 26.4 (Apple Silicon), Homebrew 5.1.5, PHP 8.5.2 — segfault at ~14 levels of nested objects.

### Fix

**Guard `dc_check_stack_limit()` with `EG(stack_limit) != NULL`** so the Zend check is skipped entirely when unconfigured, rather than silently returning `false`. On systems where `EG(stack_limit)` is properly set, nothing changes.

### Belt-and-suspenders

A `DC_MAX_DEPTH` (512) depth counter is added to `dc_ctx` as a fallback for platforms where `EG(stack_limit)` remains `NULL` even after this fix. `dc_copy_value` increments it on entry and decrements on every exit path; at the limit a `\Error` is thrown. The value matches PHP's own `PHP_SERIALIZE_NESTING_LIMIT`.

Note: on systems with very high per-level C stack usage and `EG(stack_limit)=NULL`, this fallback may still segfault before it can fire — the check runs inside the recursive frame, not before it is allocated. Proper protection requires PHP's stack limit detection to be functional.