### PR TITLE
Fix use-after-free on deep object graphs

### DIFF
--- a/deepclone.c
+++ b/deepclone.c
@@ -1396,15 +1396,21 @@ prepare_props:
 					out_name = zend_hash_add_new(Z_ARRVAL_P(out_scope), name, &new_ht);
 				}
 
-				/* Reserve dst slot at properties[scope][name][id] */
-				zval undef;
-				ZVAL_UNDEF(&undef);
-				zval *dst_slot = zend_hash_index_add_new(Z_ARRVAL_P(out_name), entry_id, &undef);
+				/* Copy value into a local zval first; only then insert into the
+				 * HashTable.  We must NOT pre-allocate a slot and pass its address
+				 * to dc_copy_value: the HashTable for out_name may grow (and thus
+				 * reallocate its arPacked) during the recursive call, turning the
+				 * pre-obtained pointer into a dangling pointer. */
+				zval local_value;
+				ZVAL_UNDEF(&local_value);
 
 				/* Mask slot: lazily allocate resolve[scope][name][id] */
 				zval mask_slot_zv;
 				ZVAL_UNDEF(&mask_slot_zv);
-				dc_copy_value(ctx, raw_val, dst_slot, &mask_slot_zv);
+				dc_copy_value(ctx, raw_val, &local_value, &mask_slot_zv);
+
+				/* HashTable is stable now — insert the finished value. */
+				zend_hash_index_add_new(Z_ARRVAL_P(out_name), entry_id, &local_value);
 				/* Drop the IS_NULL placeholders that dc_copy_array() seeded
 				 * for elements that didn't need a marker. */
 				dc_mask_cleanup(&mask_slot_zv);

--- a/tests/deepclone_deep_nesting.phpt
+++ b/tests/deepclone_deep_nesting.phpt
@@ -1,0 +1,27 @@
+--TEST--
+deepclone_to_array() handles deeply nested objects without crashing
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+$head = null;
+for ($i = 599; $i >= 0; --$i) {
+    $node = new stdClass();
+    $node->i = $i;
+    $node->next = $head;
+    $head = $node;
+}
+
+$arr = deepclone_to_array($head);
+echo "deep nesting ok\n";
+echo $arr['classes'] . "\n"; // single class → plain string
+
+// A second independent call must also work.
+$arr2 = deepclone_to_array($head);
+echo "second call ok\n";
+?>
+--EXPECT--
+deep nesting ok
+stdClass
+second call ok


### PR DESCRIPTION
When serializing a deeply nested object graph (e.g. a linked list), PHP's internal arrays can reallocate their storage as new entries are added during recursion. The extension was holding a raw pointer into one of those arrays and writing to it after the reallocation had already freed the original memory, silently corrupting unrelated data and causing a crash when building the final output.

The fix makes the recursive call write into a temporary variable, then inserts the result into the array once the call returns and the array is stable again.