### PR TITLE
Support internal final classes with __serialize/__unserialize (e.g. MongoDB BSON types)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: mongodb
           coverage: none
           tools: none
         env:
@@ -78,6 +79,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+          extensions: mongodb
           coverage: none
           tools: none
 
@@ -168,6 +170,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: mongodb
           coverage: none
           tools: none
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -395,12 +395,15 @@ static uint8_t dc_get_class_info(dc_ctx *ctx, zend_class_entry *ce)
 	}
 
 	/* Internal classes with C-level state (create_object != NULL):
-	 *   Rule A: final + create_object → always reject (no escape hatch).
-	 *   Rule B: non-final + create_object + no serialization API → reject.
-	 * Classes with __serialize/__unserialize/__sleep/__wakeup are trusted. */
+	 *   Rule A: final + no serialization API → reject.
+	 *   Rule B: non-final + no serialization API → reject.
+	 * Classes declaring __serialize/__unserialize/__sleep/__wakeup are trusted:
+	 * they round-trip via object_init_ex() + __unserialize(), same as PHP's
+	 * own serialize/unserialize. */
 	if (ce->type == ZEND_INTERNAL_CLASS
 	 && ce->create_object != NULL
 	 && (ce->ce_flags & ZEND_ACC_FINAL)
+	 && !(flags & (DC_CI_HAS_SERIALIZE | DC_CI_HAS_UNSERIALIZE | DC_CI_HAS_SLEEP | DC_CI_HAS_WAKEUP))
 	 && ce != php_ce_incomplete_class) {
 		flags |= DC_CI_NOT_INSTANTIABLE;
 	} else if (ce->type == ZEND_INTERNAL_CLASS

--- a/tests/deepclone_mongodb.phpt
+++ b/tests/deepclone_mongodb.phpt
@@ -2,12 +2,7 @@
 deepclone_to_array() / deepclone_from_array() round-trip MongoDB BSON types
 --EXTENSIONS--
 deepclone
---SKIPIF--
-<?php
-if (!extension_loaded('mongodb')) {
-    echo "skip mongodb extension not available\n";
-}
-?>
+mongodb
 --FILE--
 <?php
 
@@ -45,6 +40,8 @@ $clone = deepclone_from_array(deepclone_to_array($obj));
 var_dump($clone->a == $clone->b);    // same value
 var_dump($clone->a === $clone->b);   // object identity preserved in the graph
 var_dump($clone->a !== $oid);        // but distinct from the original
+
+echo "Done\n";
 ?>
 --EXPECT--
 bool(true)
@@ -63,3 +60,4 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
+Done

--- a/tests/deepclone_mongodb.phpt
+++ b/tests/deepclone_mongodb.phpt
@@ -1,0 +1,65 @@
+--TEST--
+deepclone_to_array() / deepclone_from_array() round-trip MongoDB BSON types
+--EXTENSIONS--
+deepclone
+--SKIPIF--
+<?php
+if (!extension_loaded('mongodb')) {
+    echo "skip mongodb extension not available\n";
+}
+?>
+--FILE--
+<?php
+
+use MongoDB\BSON;
+
+function roundtrip(mixed $value): bool
+{
+    $clone = deepclone_from_array(deepclone_to_array($value));
+    return serialize($clone) === serialize($value);
+}
+
+// Stateless types: MinKey, MaxKey
+var_dump(roundtrip(new BSON\MinKey()));
+var_dump(roundtrip(new BSON\MaxKey()));
+
+// Value types carrying state via __serialize / __unserialize
+var_dump(roundtrip(new BSON\ObjectId('507f1f77bcf86cd799439011')));
+var_dump(roundtrip(new BSON\Binary("\x00\x01\x02\x03", BSON\Binary::TYPE_GENERIC)));
+var_dump(roundtrip(new BSON\Binary(random_bytes(16), BSON\Binary::TYPE_UUID)));
+var_dump(roundtrip(new BSON\UTCDateTime(1000)));
+var_dump(roundtrip(new BSON\Regex('^foo', 'i')));
+var_dump(roundtrip(new BSON\Decimal128('3.14159265358979323846')));
+var_dump(roundtrip(new BSON\Int64(PHP_INT_MAX)));
+var_dump(roundtrip(new BSON\Timestamp(1, 1234567890)));
+var_dump(roundtrip(new BSON\Javascript('function(x) { return x; }')));
+var_dump(roundtrip(BSON\Document::fromPHP(['_id' => new BSON\ObjectId('507f1f77bcf86cd799439011'), 'n' => 1])));
+var_dump(roundtrip(BSON\PackedArray::fromPHP([new BSON\ObjectId('507f1f77bcf86cd799439011'), 42])));
+
+// Shared references: two properties pointing to the same BSON object
+$oid = new BSON\ObjectId('507f1f77bcf86cd799439011');
+$obj = new stdClass();
+$obj->a = $oid;
+$obj->b = $oid;
+$clone = deepclone_from_array(deepclone_to_array($obj));
+var_dump($clone->a == $clone->b);    // same value
+var_dump($clone->a === $clone->b);   // object identity preserved in the graph
+var_dump($clone->a !== $oid);        // but distinct from the original
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
`deepclone_to_array()` throws `NotInstantiableException` for internal final classes (those defined in a C extension) even when they declare `__serialize`/`__unserialize`. This blocks all MongoDB BSON types (`ObjectId`, `Binary`, `UTCDateTime`, …) and `MongoDB\Driver\ReadPreference`.

The rule that rejects these classes had no escape hatch — unlike the companion rule for non-final internal classes, which already skips rejection when `__serialize`/`__unserialize` is declared. This patch aligns the two rules: a final internal class that declares `__serialize`/`__unserialize` (or `__sleep`/`__wakeup`) is allowed through. Reconstruction works via PHP's standard `unserialize()` path, which calls the class's C-level allocator then `__unserialize($state)` — no reflection tricks needed.

Classes with no serialization API (Closure, Generator, Fiber, WeakMap, WeakReference, intl classes, …) remain blocked. `Manager`, `Server`, and `Cursor` are also correctly rejected: they explicitly forbid serialization and represent live connections, not value objects.