### PR TITLE
Deepclone final internal classes that lack a serialization API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mongodb
+          extensions: mongodb, tidy
           coverage: none
           tools: none
         env:
@@ -79,7 +79,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: mongodb
+          extensions: mongodb, tidy
           coverage: none
           tools: none
 
@@ -170,7 +170,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mongodb
+          extensions: mongodb, tidy
           coverage: none
           tools: none
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -394,11 +394,29 @@ static uint8_t dc_get_class_info(dc_ctx *ctx, zend_class_entry *ce)
 		flags |= DC_CI_NOT_INSTANTIABLE;
 	}
 
-	/* Internal classes with C-level state (create_object != NULL) and no
-	 * declared serialization API are rejected. Classes that declare
-	 * __serialize/__unserialize/__sleep/__wakeup are trusted — they
-	 * round-trip via object_init_ex() + __unserialize(). */
+	/* Internal classes with C-level state (create_object != NULL):
+	 *   Rule A: final + no serialization API → probe instantiation; reject if it fails.
+	 *   Rule B: non-final + no serialization API → reject.
+	 * Classes declaring __serialize/__unserialize/__sleep/__wakeup are trusted:
+	 * they round-trip via object_init_ex() + __unserialize(), same as PHP's
+	 * own serialize/unserialize.
+	 * Rule A uses a probe instead of an unconditional reject because some final
+	 * internal classes are stateless and fully reconstructable from their PHP-
+	 * visible properties (e.g. MongoDB\BSON\MinKey / MaxKey): object_init_ex()
+	 * succeeds and produces a complete object with no hidden C-level state. */
 	if (ce->type == ZEND_INTERNAL_CLASS
+	 && ce->create_object != NULL
+	 && (ce->ce_flags & ZEND_ACC_FINAL)
+	 && !(flags & (DC_CI_HAS_SERIALIZE | DC_CI_HAS_UNSERIALIZE | DC_CI_HAS_SLEEP | DC_CI_HAS_WAKEUP))
+	 && ce != php_ce_incomplete_class) {
+		zval probe;
+		if (object_init_ex(&probe, ce) != SUCCESS || EG(exception)) {
+			zend_clear_exception();
+			flags |= DC_CI_NOT_INSTANTIABLE;
+		} else {
+			zval_ptr_dtor(&probe);
+		}
+	} else if (ce->type == ZEND_INTERNAL_CLASS
 	 && ce->create_object != NULL
 	 && ce->serialize == NULL
 	 && !(flags & (DC_CI_HAS_SERIALIZE | DC_CI_HAS_UNSERIALIZE | DC_CI_HAS_SLEEP | DC_CI_HAS_WAKEUP))

--- a/tests/deepclone_rule_a_probe.phpt
+++ b/tests/deepclone_rule_a_probe.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Rule A: final internal classes with create_object but no serialization API round-trip via probe
+--EXTENSIONS--
+deepclone
+tidy
+--FILE--
+<?php
+
+// tidyNode is a final internal class with a C-level create_object handler
+// and no __serialize/__unserialize/__sleep/__wakeup.
+
+$tidy = new tidy();
+$tidy->parseString('<p><b>hello</b></p>', [], 'utf8');
+$b = $tidy->body()->child[0]->child[0]; // <b> node
+
+$clone = deepclone_from_array(deepclone_to_array($b));
+
+var_dump($clone instanceof tidyNode);
+var_dump($clone !== $b);
+var_dump($clone->name === $b->name);
+var_dump($clone->value === $b->value);
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done


### PR DESCRIPTION
Some final internal PHP classes (e.g. `tidyNode`, `MongoDB\BSON\MinKey`, `MongoDB\BSON\MaxKey`) are perfectly constructible but have no `__serialize`/`__unserialize`/`__sleep`/`__wakeup`. The extension was rejecting all of them as not instantiable.

This PR probes each such class once (at class-info cache time) by calling the C-level constructor. If it succeeds, the class is deepcloned normally; if it throws, the class is still rejected. The result is cached so the probe only runs once per class per request.

A PHPT test using `tidyNode` (part of PHP's bundled `tidy` extension) covers the probe path, and CI now loads `tidy` alongside `mongodb`.

This is the C extension counterpart of the polyfill fix in symfony/polyfill#562.