### PR TITLE
Address review feedback + add forgiving-hydrate behaviors and $flags parameter (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   slot already holds an identical value (`===`). Avoids "Cannot modify
   readonly property" on idempotent rehydration. Writes to uninitialized
   readonly and to different-valued readonly still obey engine semantics.
+- `deepclone_hydrate()` writes `null` into a non-nullable typed property
+  as `unset()` (restoring the uninitialized state) instead of raising
+  `TypeError`. Nullable/mixed types keep their existing semantics. Not
+  applied under `DEEPCLONE_HYDRATE_CALL_HOOKS`, where the user's set
+  hook may legitimately handle `null`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   choose the write semantics for declared-property assignments:
   - `DEEPCLONE_HYDRATE_CALL_HOOKS` — `ReflectionProperty::setValue`
     semantics: invoke user-defined set hooks on hooked properties.
+  - `DEEPCLONE_HYDRATE_NO_LAZY_INIT` —
+    `ReflectionProperty::setRawValueWithoutLazyInitialization` semantics:
+    skip the lazy initializer for each written property; realize the
+    object when the last lazy property is set. Delegated to the
+    Reflection API because the engine helpers the method relies on
+    (`zend_lazy_object_decr_lazy_props`, `zend_lazy_object_realize`) are
+    not exported as `ZEND_API`.
   - Default (0) — `setRawValue` semantics (bypass set hooks, type-check).
-  - Unknown bits are rejected with `ValueError`.
-  - Lazy-object semantics: writes go through the engine's standard path,
-    so the lazy initializer fires on first access (matching `setValue` /
-    `setRawValue`). Suppressing the initializer requires
-    `ReflectionProperty::setRawValueWithoutLazyInitialization`, whose
-    backing helpers (`zend_lazy_object_decr_lazy_props`,
-    `zend_lazy_object_realize`) are not exported as `ZEND_API` and so
-    aren't available to a shared extension.
+  - The two flags are mutually exclusive; unknown bits are rejected with
+    `ValueError`.
 - `deepclone_from_array()` always uses the default setRawValue semantics
   (same policy as `unserialize()` — payload-driven).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `deepclone_hydrate(..., int $flags = 0)` — new optional parameter to
+  choose the write semantics for declared-property assignments:
+  - `DEEPCLONE_HYDRATE_CALL_HOOKS` — `ReflectionProperty::setValue`
+    semantics: invoke user-defined set hooks on hooked properties.
+  - Default (0) — `setRawValue` semantics (bypass set hooks, type-check).
+  - Unknown bits are rejected with `ValueError`.
+  - Lazy-object semantics: writes go through the engine's standard path,
+    so the lazy initializer fires on first access (matching `setValue` /
+    `setRawValue`). Suppressing the initializer requires
+    `ReflectionProperty::setRawValueWithoutLazyInitialization`, whose
+    backing helpers (`zend_lazy_object_decr_lazy_props`,
+    `zend_lazy_object_realize`) are not exported as `ZEND_API` and so
+    aren't available to a shared extension.
+- `deepclone_from_array()` always uses the default setRawValue semantics
+  (same policy as `unserialize()` — payload-driven).
+
 ## [0.2.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BC Break
+
+- `deepclone_hydrate()` now takes a single `$vars` array instead of
+  separate `$scoped_vars` and `$mangled_vars`. The default interpretation
+  is the scoped per-class shape; pass the new `DEEPCLONE_HYDRATE_MANGLED_VARS`
+  flag in `$flags` to interpret `$vars` as a flat mangled-key array (the
+  shape `(array) $object` produces). Old positional callers
+  (`deepclone_hydrate($obj, [], $mangled)`) need to be updated to
+  `deepclone_hydrate($obj, $mangled, DEEPCLONE_HYDRATE_MANGLED_VARS)`.
+  As a footgun guard, passing a NUL-prefixed key in scoped mode raises
+  a `ValueError` pointing at the missing flag.
+
+### Added
+
+- `DEEPCLONE_HYDRATE_MANGLED_VARS` constant — see BC break above.
+
 ### Changed
 
 - `deepclone_hydrate()` silently skips readonly writes when the target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `deepclone_hydrate()` silently skips readonly writes when the target
+  slot already holds an identical value (`===`). Avoids "Cannot modify
+  readonly property" on idempotent rehydration. Writes to uninitialized
+  readonly and to different-valued readonly still obey engine semantics.
+
 ### Added
 
 - `deepclone_hydrate(..., int $flags = 0)` — new optional parameter to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readonly and to different-valued readonly still obey engine semantics.
 - `deepclone_hydrate()` writes `null` into a non-nullable typed property
   as `unset()` (restoring the uninitialized state) instead of raising
-  `TypeError`. Nullable/mixed types keep their existing semantics. Not
-  applied under `DEEPCLONE_HYDRATE_CALL_HOOKS`, where the user's set
-  hook may legitimately handle `null`.
+  `TypeError`. Nullable/mixed types keep their existing semantics.
+  Hooked properties are exempt (no backing slot to "unset"; the set
+  hook may handle `null` itself).
+- `deepclone_hydrate()` casts scalar values to the matching backed-enum
+  case when the target is a single-type (possibly nullable) backed-enum
+  property and the value matches the enum's backing type (`int` ↔ int-
+  backed, `string` ↔ string-backed). Unknown backing values raise the
+  standard `ValueError` from `Enum::from()`. Decision rests on the
+  property type only — `DEEPCLONE_HYDRATE_CALL_HOOKS` and hook presence
+  don't change it. Set hooks on enum-typed properties accordingly
+  receive the enum case, not the raw scalar.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ deepclone_hydrate($existingUser, ['User' => ['name' => 'Bob']]);
 ```php
 function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array;
 function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed;
-function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = []): object;
+function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = [], int $flags = 0): object;
 ```
 
 `$allowed_classes` restricts which classes may be serialized or deserialized
@@ -96,6 +96,23 @@ declaring class name, each value being an array of property names to values.
 (`"\0ClassName\0prop"` for private, `"\0*\0prop"` for protected, bare name
 for public/dynamic). It resolves each key to the correct scope automatically,
 which is handy when round-tripping with `(array)` casts.
+
+`$flags` selects the write semantics for declared-property assignments:
+
+| Flag                                   | Semantics                                  |
+|----------------------------------------|--------------------------------------------|
+| `0` (default)                          | `ReflectionProperty::setRawValue` — bypass set hooks, type-check, respect readonly |
+| `DEEPCLONE_HYDRATE_CALL_HOOKS`         | `ReflectionProperty::setValue` — invoke set hooks |
+
+`deepclone_from_array()` always uses the default setRawValue semantics,
+mirroring `unserialize()`.
+
+For lazy objects, writes go through the engine's standard path, so the
+lazy initializer fires on first access — same as `ReflectionProperty::setValue`
+or `setRawValue`. Suppressing the initializer requires
+`ReflectionProperty::setRawValueWithoutLazyInitialization`, which depends
+on engine helpers that aren't `ZEND_API`-exported and therefore aren't
+reachable from a shared extension.
 
 The special `"\0"` key sets the internal state of SPL classes. In
 `$scoped_vars` it goes inside a scope entry; in `$mangled_vars` it is a

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ $user = deepclone_hydrate(User::class, [
 ]);
 
 // Instantiate from class name with mangled keys (same format as (array) cast)
-$user = deepclone_hydrate(User::class, [], ['name' => 'Alice', 'email' => 'alice@example.com']);
+$user = deepclone_hydrate(User::class,
+    ['name' => 'Alice', 'email' => 'alice@example.com'],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
 
 // Hydrate an existing object
 deepclone_hydrate($existingUser, ['User' => ['name' => 'Bob']]);
@@ -74,7 +77,7 @@ deepclone_hydrate($existingUser, ['User' => ['name' => 'Bob']]);
 ```php
 function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array;
 function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed;
-function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = [], int $flags = 0): object;
+function deepclone_hydrate(object|string $object_or_class, array $vars = [], int $flags = 0): object;
 ```
 
 `$allowed_classes` restricts which classes may be serialized or deserialized
@@ -83,19 +86,31 @@ function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = 
 the list.
 
 `deepclone_hydrate()` accepts either an object to hydrate in place or a class
-name to instantiate without calling its constructor. Both `$scoped_vars` and
-`$mangled_vars` can be used together; `$mangled_vars` values are resolved
-and merged into `$scoped_vars` before hydration. PHP `&` references are
-preserved in both.
+name to instantiate without calling its constructor. PHP `&` references in
+`$vars` are preserved through the hydrate.
 
-`$scoped_vars` is the **fastest path** — it writes directly to property
-slots with no key parsing, making it ideal for hot loops. It is keyed by
-declaring class name, each value being an array of property names to values.
+By default, `$vars` is keyed by declaring class name; each value is an array
+of property names to values. This is the fastest path — direct slot writes,
+no key parsing.
 
-`$mangled_vars` accepts the same mangled key format as `(array) $object`
-(`"\0ClassName\0prop"` for private, `"\0*\0prop"` for protected, bare name
-for public/dynamic). It resolves each key to the correct scope automatically,
-which is handy when round-tripping with `(array)` casts.
+```php
+$user = deepclone_hydrate(User::class, [
+    User::class => ['id' => 42, 'name' => 'Alice'],
+    AbstractEntity::class => ['createdAt' => new \DateTimeImmutable()],
+]);
+```
+
+Pass `DEEPCLONE_HYDRATE_MANGLED_VARS` in `$flags` to interpret `$vars` as a
+flat mangled-key array (the same shape `(array) $object` produces):
+`"\0ClassName\0prop"` for private, `"\0*\0prop"` for protected, bare name
+for public/dynamic. Each key is resolved to its scope automatically.
+
+```php
+$user = deepclone_hydrate(User::class,
+    ['name' => 'Alice', "\0User\0email" => 'alice@example.com'],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
+```
 
 `$flags` selects the write semantics for declared-property assignments:
 
@@ -104,10 +119,11 @@ which is handy when round-tripping with `(array)` casts.
 | `0` (default)                          | `ReflectionProperty::setRawValue` — bypass set hooks, type-check, respect readonly |
 | `DEEPCLONE_HYDRATE_CALL_HOOKS`         | `ReflectionProperty::setValue` — invoke set hooks |
 | `DEEPCLONE_HYDRATE_NO_LAZY_INIT`       | `ReflectionProperty::setRawValueWithoutLazyInitialization` — skip the lazy initializer; realize the object when the last lazy property is set |
+| `DEEPCLONE_HYDRATE_MANGLED_VARS`       | interpret `$vars` as a flat mangled-key array (above) |
 
 `DEEPCLONE_HYDRATE_CALL_HOOKS` and `DEEPCLONE_HYDRATE_NO_LAZY_INIT` are
-mutually exclusive. `deepclone_from_array()` always uses the default
-setRawValue semantics, mirroring `unserialize()`.
+mutually exclusive; `MANGLED_VARS` composes with either. `deepclone_from_array()`
+always uses the default setRawValue semantics, mirroring `unserialize()`.
 
 ### Forgiving payload handling
 
@@ -140,19 +156,24 @@ strict-type errors. They run under every mode unless noted:
   enum-typed properties accordingly receive the enum case, not the
   raw scalar.
 
-The special `"\0"` key sets the internal state of SPL classes. In
-`$scoped_vars` it goes inside a scope entry; in `$mangled_vars` it is a
-flat key:
+The special `"\0"` key sets the internal state of SPL classes. In scoped
+mode it goes inside a scope entry; in `MANGLED_VARS` mode it is a flat key:
 
 ```php
-// Via $scoped_vars:
+// Scoped mode:
 $ao = deepclone_hydrate('ArrayObject', ['ArrayObject' => ["\0" => [['x' => 1]]]]);
 
-// Via $mangled_vars:
-$ao = deepclone_hydrate('ArrayObject', [], ["\0" => [['x' => 1], ArrayObject::ARRAY_AS_PROPS]]);
+// MANGLED_VARS mode:
+$ao = deepclone_hydrate('ArrayObject',
+    ["\0" => [['x' => 1], ArrayObject::ARRAY_AS_PROPS]],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
 
 // SplObjectStorage: "\0" => [$obj1, $info1, $obj2, $info2, ...]
-$s = deepclone_hydrate('SplObjectStorage', [], ["\0" => [$obj, 'metadata']]);
+$s = deepclone_hydrate('SplObjectStorage',
+    ["\0" => [$obj, 'metadata']],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
 ```
 
 ## What it preserves

--- a/README.md
+++ b/README.md
@@ -114,6 +114,37 @@ or `setRawValue`. Suppressing the initializer requires
 on engine helpers that aren't `ZEND_API`-exported and therefore aren't
 reachable from a shared extension.
 
+### Forgiving payload handling
+
+`deepclone_hydrate()` applies three coercions before writing each
+declared property, so common rehydration patterns don't trip on
+strict-type errors. They run under every mode unless noted:
+
+- **Readonly idempotent skip** — when the readonly slot already holds an
+  identical value (`===`), the write is silently skipped. Avoids
+  `Error: Cannot modify readonly property` on no-op rehydration.
+  Different values still raise the engine's normal error.
+- **`null` → `unset()` for non-nullable typed properties** — writing
+  `null` into a non-nullable typed slot stores the uninitialized state
+  (so `ReflectionProperty::isInitialized()` returns `false` and reads
+  raise the standard "must not be accessed before initialization"
+  error) instead of throwing `TypeError`. This restores a state
+  otherwise unreachable through hydration. Nullable / `mixed` types
+  keep their existing semantics. Hooked properties never trigger this
+  rule (no backing slot to "unset" semantically; a set hook may handle
+  `null` itself).
+- **Scalar → backed-enum cast** — when the property is typed with a
+  single (possibly nullable) backed enum and the payload value is a
+  scalar matching the enum's backing type (`int` ↔ int-backed,
+  `string` ↔ string-backed), the value is cast to the corresponding
+  case. Unknown backing values raise the standard `ValueError` ("X is
+  not a valid backing value for enum Y"), matching `Enum::from()`.
+  Union/intersection types on the property itself are left untouched.
+  The decision rests on the property type only — hook presence and
+  `DEEPCLONE_HYDRATE_CALL_HOOKS` mode don't change it. Set hooks on
+  enum-typed properties accordingly receive the enum case, not the
+  raw scalar.
+
 The special `"\0"` key sets the internal state of SPL classes. In
 `$scoped_vars` it goes inside a scope entry; in `$mangled_vars` it is a
 flat key:

--- a/README.md
+++ b/README.md
@@ -103,16 +103,11 @@ which is handy when round-tripping with `(array)` casts.
 |----------------------------------------|--------------------------------------------|
 | `0` (default)                          | `ReflectionProperty::setRawValue` — bypass set hooks, type-check, respect readonly |
 | `DEEPCLONE_HYDRATE_CALL_HOOKS`         | `ReflectionProperty::setValue` — invoke set hooks |
+| `DEEPCLONE_HYDRATE_NO_LAZY_INIT`       | `ReflectionProperty::setRawValueWithoutLazyInitialization` — skip the lazy initializer; realize the object when the last lazy property is set |
 
-`deepclone_from_array()` always uses the default setRawValue semantics,
-mirroring `unserialize()`.
-
-For lazy objects, writes go through the engine's standard path, so the
-lazy initializer fires on first access — same as `ReflectionProperty::setValue`
-or `setRawValue`. Suppressing the initializer requires
-`ReflectionProperty::setRawValueWithoutLazyInitialization`, which depends
-on engine helpers that aren't `ZEND_API`-exported and therefore aren't
-reachable from a shared extension.
+`DEEPCLONE_HYDRATE_CALL_HOOKS` and `DEEPCLONE_HYDRATE_NO_LAZY_INIT` are
+mutually exclusive. `deepclone_from_array()` always uses the default
+setRawValue semantics, mirroring `unserialize()`.
 
 ### Forgiving payload handling
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -67,6 +67,7 @@
  * linker resolves the symbols against the loaded PHP binary at runtime. */
 extern PHPAPI zend_class_entry *reflector_ptr;
 extern PHPAPI zend_class_entry *reflection_type_ptr;
+extern PHPAPI zend_class_entry *reflection_property_ptr;
 
 /* ── Compatibility shims for older PHP versions ────────────── */
 
@@ -150,7 +151,9 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
 /* Public flags for deepclone_hydrate()'s $flags parameter. Exported as
  * PHP-level constants via deepclone.stub.php; values must match. */
 #define DEEPCLONE_HYDRATE_CALL_HOOKS    (1 << 0)
-#define DEEPCLONE_HYDRATE_FLAGS_MASK    (DEEPCLONE_HYDRATE_CALL_HOOKS)
+#define DEEPCLONE_HYDRATE_NO_LAZY_INIT  (1 << 1)
+#define DEEPCLONE_HYDRATE_FLAGS_MASK \
+	(DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT)
 
 /* The stub-generated header relies on the compat shims above (specifically
  * zend_register_internal_class_with_flags on PHP < 8.4), so it has to be
@@ -652,10 +655,89 @@ static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)
 		&& !(pi->flags & (ZEND_ACC_PROTECTED_SET | ZEND_ACC_PRIVATE_SET));
 }
 
+#if PHP_VERSION_ID >= 80400
+/* fn_proxy slot cached across calls — first invocation fills it via method
+ * lookup; subsequent invocations reuse the resolved zend_function*. */
+static zend_function *dc_set_raw_no_lazy_fn = NULL;
+
+/* HashTable destructor for lazy_init_refl_cache (releases cached
+ * ReflectionProperty instances). Defined later; forward-declared here. */
+static void dc_lazy_refl_cache_dtor(zval *zv);
+
+/* Delegate a single property write to
+ * ReflectionProperty::setRawValueWithoutLazyInitialization($obj, $value).
+ * The reflection method handles lazy-prop flag clearing, counter decrement,
+ * and object realization via engine-internal helpers that aren't exposed as
+ * ZEND_API. Going through the PHP API avoids duplicating those internals.
+ * Caller is expected to fast-path the non-lazy case before calling this.
+ *
+ * Per-request cache: the constructed ReflectionProperty for a given pi
+ * is reusable across many target objects (it holds the class/property
+ * reference, not the instance), so we cache one instance per pi pointer.
+ * Returns false if an exception was raised. */
+static bool dc_set_raw_value_without_lazy_init(zend_object *obj,
+	zend_property_info *pi, zend_string *name, zval *value)
+{
+	HashTable *cache = &DC_G(lazy_init_refl_cache);
+	zend_object *refl_obj = NULL;
+
+	if (cache->nTableSize) {
+		refl_obj = zend_hash_index_find_ptr(cache, (zend_ulong) (uintptr_t) pi);
+	}
+
+	if (!refl_obj) {
+		zval refl_zv;
+		if (UNEXPECTED(object_init_ex(&refl_zv, reflection_property_ptr) != SUCCESS)) {
+			return false;
+		}
+
+		zval ctor_args[2];
+		ZVAL_STR_COPY(&ctor_args[0], pi->ce->name);
+		ZVAL_STR_COPY(&ctor_args[1], name);
+
+		zend_call_method_with_2_params(Z_OBJ(refl_zv), reflection_property_ptr,
+			&reflection_property_ptr->constructor, "__construct", NULL,
+			&ctor_args[0], &ctor_args[1]);
+
+		zval_ptr_dtor(&ctor_args[0]);
+		zval_ptr_dtor(&ctor_args[1]);
+
+		if (UNEXPECTED(EG(exception))) {
+			zval_ptr_dtor(&refl_zv);
+			return false;
+		}
+
+		if (!cache->nTableSize) {
+			zend_hash_init(cache, 8, NULL, dc_lazy_refl_cache_dtor, 0);
+		}
+		refl_obj = Z_OBJ(refl_zv);
+		zend_hash_index_add_ptr(cache, (zend_ulong) (uintptr_t) pi, refl_obj);
+		/* Cache holds the only reference; refcount stays at 1. */
+	}
+
+	zval method_args[2];
+	ZVAL_OBJ_COPY(&method_args[0], obj);
+	ZVAL_COPY(&method_args[1], value);
+
+	zend_call_method_with_2_params(refl_obj, reflection_property_ptr,
+		&dc_set_raw_no_lazy_fn,
+		"setRawValueWithoutLazyInitialization", NULL,
+		&method_args[0], &method_args[1]);
+
+	zval_ptr_dtor(&method_args[0]);
+	zval_ptr_dtor(&method_args[1]);
+
+	return !EG(exception);
+}
+#endif
+
 /* Write a declared property. Default (flags == 0) matches
  * ReflectionProperty::setRawValue: bypass set hooks, type-check, preserve
  * readonly. Flags:
  *  - DEEPCLONE_HYDRATE_CALL_HOOKS: setValue semantics — invoke set hooks.
+ *  - DEEPCLONE_HYDRATE_NO_LAZY_INIT: setRawValueWithoutLazyInitialization —
+ *    skip lazy-init on the target slot; realize the object when the last
+ *    lazy property is initialized. Delegates to ReflectionProperty.
  *
  * Dispatch:
  *  - Non-typed, non-hooked: direct slot write (fast path, dtor-safe).
@@ -665,20 +747,17 @@ static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)
  *    check inside zend_std_write_property short-circuits to the direct
  *    backing write, bypassing the user set hook while still type-checking.
  *  - Hooked non-virtual (CALL_HOOKS): zend_update_property_ex — hook invoked.
- *
- * Lazy objects: writes go through the engine's standard path, which triggers
- * the lazy initializer on first access (matching ReflectionProperty::setValue
- * / setRawValue semantics). Suppressing initialization requires
- * ReflectionProperty::setRawValueWithoutLazyInitialization, which depends on
- * non-public engine APIs (zend_lazy_object_decr_lazy_props /
- * zend_lazy_object_realize) that aren't available to shared extensions.
+ *  - NO_LAZY_INIT (any prop shape): delegate to ReflectionProperty.
  *
  * Caller must have verified dc_is_backed_declared_property(pi). Returns false
  * if a TypeError (or any exception) was raised by the engine. */
 static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 	zend_string *name, zval *value, zend_long flags)
 {
-	bool call_hooks = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
+	bool call_hooks   = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
+#if PHP_VERSION_ID >= 80400
+	bool no_lazy_init = (flags & DEEPCLONE_HYDRATE_NO_LAZY_INIT) != 0;
+#endif
 	zval *slot = OBJ_PROP(obj, pi->offset);
 
 	/* Readonly same-value skip: avoid the engine's "Cannot modify readonly
@@ -745,6 +824,23 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 			value = &enum_holder;
 			enum_holder_used = true;
 		}
+	}
+#endif
+
+#if PHP_VERSION_ID >= 80400
+	/* Fast path: NO_LAZY_INIT only matters when the object is a lazy ghost
+	 * or proxy with at least one uninitialized lazy property. Otherwise the
+	 * default write path produces identical results without paying for the
+	 * Reflection round-trip. zend_lazy_object_initialized is a header-resident
+	 * static inline, so it's free to call. */
+	if (no_lazy_init && !zend_lazy_object_initialized(obj)) {
+		bool ok = dc_set_raw_value_without_lazy_init(obj, pi, name, value);
+#if PHP_VERSION_ID >= 80100
+		if (enum_holder_used) {
+			zval_ptr_dtor(&enum_holder);
+		}
+#endif
+		return ok;
 	}
 #endif
 
@@ -2873,6 +2969,10 @@ PHP_FUNCTION(deepclone_hydrate)
 		zend_value_error("deepclone_hydrate(): Argument #4 ($flags) contains unknown bits");
 		RETURN_THROWS();
 	}
+	if (UNEXPECTED((flags & DEEPCLONE_HYDRATE_CALL_HOOKS) && (flags & DEEPCLONE_HYDRATE_NO_LAZY_INIT))) {
+		zend_value_error("deepclone_hydrate(): Argument #4 ($flags) DEEPCLONE_HYDRATE_CALL_HOOKS and DEEPCLONE_HYDRATE_NO_LAZY_INIT are mutually exclusive");
+		RETURN_THROWS();
+	}
 
 	zval obj_zval;
 
@@ -3327,11 +3427,31 @@ static PHP_GINIT_FUNCTION(deepclone)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 	zend_hash_init(&deepclone_globals->hydrate_cache, 8, NULL, NULL, 1);
+	/* lazy_init_refl_cache holds zend_object* (request-scoped). Initialized
+	 * lazily on first use in RINIT-equivalent flow; cleared in RSHUTDOWN. */
+	memset(&deepclone_globals->lazy_init_refl_cache, 0, sizeof(HashTable));
 }
 
 static PHP_GSHUTDOWN_FUNCTION(deepclone)
 {
 	zend_hash_destroy(&deepclone_globals->hydrate_cache);
+}
+
+#if PHP_VERSION_ID >= 80400
+static void dc_lazy_refl_cache_dtor(zval *zv)
+{
+	zend_object_release((zend_object *) Z_PTR_P(zv));
+}
+#endif
+
+static PHP_RSHUTDOWN_FUNCTION(deepclone)
+{
+	HashTable *cache = &DC_G(lazy_init_refl_cache);
+	if (cache->nTableSize) {
+		zend_hash_destroy(cache);
+		memset(cache, 0, sizeof(HashTable));
+	}
+	return SUCCESS;
 }
 
 PHP_MINFO_FUNCTION(deepclone)
@@ -3351,7 +3471,7 @@ zend_module_entry deepclone_module_entry = {
 	PHP_MINIT(deepclone),
 	NULL, /* MSHUTDOWN */
 	NULL, /* RINIT */
-	NULL, /* RSHUTDOWN */
+	PHP_RSHUTDOWN(deepclone),
 	PHP_MINFO(deepclone),
 	PHP_DEEPCLONE_VERSION,
 	PHP_MODULE_GLOBALS(deepclone),

--- a/deepclone.c
+++ b/deepclone.c
@@ -141,6 +141,12 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
 # endif
 #endif
 
+#if PHP_VERSION_ID >= 80400
+# define DC_PROP_HAS_HOOKS(pi) ((pi)->hooks != NULL)
+#else
+# define DC_PROP_HAS_HOOKS(pi) (0)
+#endif
+
 /* The stub-generated header relies on the compat shims above (specifically
  * zend_register_internal_class_with_flags on PHP < 8.4), so it has to be
  * included after this point. */
@@ -620,12 +626,12 @@ static zend_always_inline bool dc_class_allowed(HashTable *set, zend_string *nam
 	return found;
 }
 
-static zend_always_inline bool dc_can_direct_write_property(zend_property_info *pi)
+static zend_always_inline bool dc_is_backed_declared_property(zend_property_info *pi)
 {
-	/* Direct slot write bypasses set hooks (matches ReflectionProperty::setRawValue
-	 * semantics). Requires a real backing slot: reject virtual properties and
-	 * any offset sentinel. Non-virtual hooked properties have a real backing
-	 * offset (>= ZEND_FIRST_PROPERTY_OFFSET) and are safe to write directly. */
+	/* A "backed declared property" is a non-static, non-virtual property with
+	 * a real backing slot (offset >= ZEND_FIRST_PROPERTY_OFFSET). Hooked
+	 * non-virtual properties qualify (they have a real offset); virtual
+	 * properties and hook-metadata offsets do not. */
 	return pi
 		&& !(pi->flags & ZEND_ACC_STATIC)
 		&& !(pi->flags & ZEND_ACC_VIRTUAL)
@@ -641,22 +647,42 @@ static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)
 		&& !(pi->flags & (ZEND_ACC_PROTECTED_SET | ZEND_ACC_PRIVATE_SET));
 }
 
-static zend_always_inline void dc_write_property_slot(zend_object *obj, zend_property_info *pi, zval *value)
+/* Write a declared property, matching ReflectionProperty::setRawValue semantics:
+ *  - Non-typed, non-hooked: direct slot write (fast path, dtor-reentrancy safe).
+ *  - Typed non-hooked: zend_update_property_ex with the declaring class as
+ *    fake scope — engine type-checks (coerces under non-strict).
+ *  - Hooked non-virtual: invoke the set-hook trampoline. The trampoline's
+ *    execute_data->func carries prop_info, so the recursion check inside
+ *    zend_std_write_property (zend_is_in_hook / zend_should_call_hook) short-
+ *    circuits to the direct backing write, bypassing the user set hook while
+ *    still type-checking. This is exactly what ReflectionProperty::setRawValue
+ *    does.
+ * Caller must have verified dc_is_backed_declared_property(pi). Returns false
+ * if a TypeError (or any exception) was raised by the engine. */
+static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
+	zend_string *name, zval *value)
 {
-	zval *slot = OBJ_PROP(obj, pi->offset);
-	/* Move the old value out before running its destructor: a __destruct on
-	 * the old value can legitimately read (or even reassign) this same slot.
-	 * Install the new value first so reentrant reads see a valid, typed slot. */
-	zval old;
-	ZVAL_COPY_VALUE(&old, slot);
-	if (Z_ISREF(old) && ZEND_TYPE_IS_SET(pi->type)) {
-		ZEND_REF_DEL_TYPE_SOURCE(Z_REF(old), pi);
+	if (!ZEND_TYPE_IS_SET(pi->type) && !DC_PROP_HAS_HOOKS(pi)) {
+		zval *slot = OBJ_PROP(obj, pi->offset);
+		/* Move the old value out before running its destructor: a __destruct
+		 * on the old value can legitimately read (or reassign) this same slot.
+		 * Install the new value first so reentrant reads see a valid slot. */
+		zval old;
+		ZVAL_COPY_VALUE(&old, slot);
+		ZVAL_COPY(slot, value);
+		zval_ptr_dtor(&old);
+		return true;
 	}
-	ZVAL_COPY(slot, value);
-	if (Z_ISREF_P(slot) && ZEND_TYPE_IS_SET(pi->type)) {
-		ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(slot), pi);
+#if PHP_VERSION_ID >= 80400
+	if (DC_PROP_HAS_HOOKS(pi) && pi->hooks[ZEND_PROPERTY_HOOK_SET]) {
+		zend_function *trampoline = zend_get_property_hook_trampoline(
+			pi, ZEND_PROPERTY_HOOK_SET, name);
+		zend_call_known_instance_method_with_1_params(trampoline, obj, NULL, value);
+		return !EG(exception);
 	}
-	zval_ptr_dtor(&old);
+#endif
+	zend_update_property_ex(pi->ce, obj, name, value);
+	return !EG(exception);
 }
 
 /* ── Core traversal ─────────────────────────────────────────── */
@@ -2615,12 +2641,17 @@ PHP_FUNCTION(deepclone_from_array)
 						DC_INVALID("deepclone_from_array(): Argument #1 ($data) \"properties\" value for \"%s::%s\" does not match a declared property on object id " ZEND_ULONG_FMT,
 							ZSTR_VAL(scope_name), ZSTR_VAL(prop_name), obj_id);
 					}
-					if (dc_can_direct_write_property(use_pi)) {
-						/* Fast path: direct OBJ_PROP slot write (same as deepclone_hydrate).
-						 * pi->offset is valid on any subclass because inherited slots
-						 * preserve their offsets in the object layout. */
-						dc_write_property_slot(obj, use_pi, &final_val);
+					if (dc_is_backed_declared_property(use_pi)) {
+						/* setRawValue-style write: direct slot for non-typed
+						 * non-hooked (fast path), engine path otherwise — the
+						 * engine type-checks, bypasses set hooks on hooked
+						 * non-virtual, and tracks refs/type-sources. */
+						bool ok = dc_write_backed_property(obj, use_pi, prop_name, &final_val);
 						zval_ptr_dtor(&final_val);
+						if (UNEXPECTED(!ok)) {
+							EG(fake_scope) = old_scope;
+							goto cleanup;
+						}
 					} else if (scope_is_std && obj->ce == zend_standard_class_def) {
 						if (UNEXPECTED(!obj->properties)) {
 							rebuild_object_properties_internal(obj);
@@ -2758,7 +2789,7 @@ PHP_FUNCTION(deepclone_hydrate)
 				"Class \"%s\" not found.", ZSTR_VAL(class_name));
 			RETURN_THROWS();
 		}
-		if (UNEXPECTED(ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_ENUM))) {
+		if (UNEXPECTED(ce->ce_flags & ZEND_ACC_UNINSTANTIABLE)) {
 			zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 				"Class \"%s\" is not instantiable.", ZSTR_VAL(ce->name));
 			RETURN_THROWS();
@@ -3105,8 +3136,14 @@ add_to_scope:
 					zval *zv = zend_hash_find_known_hash(&scope_ce->properties_info, prop_name);
 					if (zv) pi = Z_PTR_P(zv);
 				}
-				if (dc_can_direct_write_property(pi)) {
-					dc_write_property_slot(obj, pi, prop_val);
+				if (dc_is_backed_declared_property(pi)) {
+					bool ok = dc_write_backed_property(obj, pi, prop_name, prop_val);
+					if (UNEXPECTED(!ok)) {
+						EG(fake_scope) = old_scope;
+						if (scoped_owned) zval_ptr_dtor(&local_scoped);
+						zval_ptr_dtor(&obj_zval);
+						RETURN_THROWS();
+					}
 				} else {
 					/* Fallback: dynamic property or unknown name — validate first */
 					if (UNEXPECTED(memchr(ZSTR_VAL(prop_name), '\0', ZSTR_LEN(prop_name)) != NULL)) {

--- a/deepclone.c
+++ b/deepclone.c
@@ -692,6 +692,30 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		return true;
 	}
 
+	/* null into a non-nullable typed slot: unset instead of raising
+	 * TypeError. Restores the "uninitialized typed" state that would
+	 * otherwise be unreachable via hydration. Hooked properties are
+	 * excluded outright (no backing slot to "unset" semantically, plus
+	 * a set hook may legitimately handle null) — gate is per-prop, so
+	 * non-hooked typed props in a CALL_HOOKS-mode hydrate still get the
+	 * forgiving treatment. */
+	if (Z_TYPE_P(value) == IS_NULL
+		&& ZEND_TYPE_IS_SET(pi->type)
+		&& !ZEND_TYPE_ALLOW_NULL(pi->type)
+		&& !DC_PROP_HAS_HOOKS(pi))
+	{
+		if (Z_TYPE_P(slot) != IS_UNDEF) {
+			zval old;
+			ZVAL_COPY_VALUE(&old, slot);
+			ZVAL_UNDEF(slot);
+			Z_PROP_FLAG_P(slot) |= IS_PROP_UNINIT;
+			zval_ptr_dtor(&old);
+		} else {
+			Z_PROP_FLAG_P(slot) |= IS_PROP_UNINIT;
+		}
+		return true;
+	}
+
 	if (!ZEND_TYPE_IS_SET(pi->type) && !DC_PROP_HAS_HOOKS(pi)) {
 		/* Move the old value out before running its destructor: a __destruct
 		 * on the old value can legitimately read (or reassign) this same slot.

--- a/deepclone.c
+++ b/deepclone.c
@@ -20,8 +20,8 @@
  *     Throws \ValueError on malformed input.
  *
  *   function deepclone_hydrate(object|string $object_or_class,
- *                              array $scoped_vars = [],
- *                              array $mangled_vars = []): object
+ *                              array $vars = [],
+ *                              int $flags = 0): object
  *     Instantiates a class (or takes an existing object) and sets its
  *     properties — including private, protected, and readonly — via direct
  *     property-slot writes. Replaces Symfony's Hydrator/Instantiator.
@@ -152,8 +152,9 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
  * PHP-level constants via deepclone.stub.php; values must match. */
 #define DEEPCLONE_HYDRATE_CALL_HOOKS    (1 << 0)
 #define DEEPCLONE_HYDRATE_NO_LAZY_INIT  (1 << 1)
+#define DEEPCLONE_HYDRATE_MANGLED_VARS  (1 << 2)
 #define DEEPCLONE_HYDRATE_FLAGS_MASK \
-	(DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT)
+	(DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT | DEEPCLONE_HYDRATE_MANGLED_VARS)
 
 /* The stub-generated header relies on the compat shims above (specifically
  * zend_register_internal_class_with_flags on PHP < 8.4), so it has to be
@@ -664,17 +665,9 @@ static zend_function *dc_set_raw_no_lazy_fn = NULL;
  * ReflectionProperty instances). Defined later; forward-declared here. */
 static void dc_lazy_refl_cache_dtor(zval *zv);
 
-/* Delegate a single property write to
- * ReflectionProperty::setRawValueWithoutLazyInitialization($obj, $value).
- * The reflection method handles lazy-prop flag clearing, counter decrement,
- * and object realization via engine-internal helpers that aren't exposed as
- * ZEND_API. Going through the PHP API avoids duplicating those internals.
- * Caller is expected to fast-path the non-lazy case before calling this.
- *
- * Per-request cache: the constructed ReflectionProperty for a given pi
- * is reusable across many target objects (it holds the class/property
- * reference, not the instance), so we cache one instance per pi pointer.
- * Returns false if an exception was raised. */
+/* Delegates to ReflectionProperty::setRawValueWithoutLazyInitialization because the
+ * required engine helpers (zend_lazy_object_decr_lazy_props, _realize) aren't ZEND_API.
+ * Per-request cache keyed on pi — the ReflectionProperty is per-class, not per-instance. */
 static bool dc_set_raw_value_without_lazy_init(zend_object *obj,
 	zend_property_info *pi, zend_string *name, zval *value)
 {
@@ -731,38 +724,21 @@ static bool dc_set_raw_value_without_lazy_init(zend_object *obj,
 }
 #endif
 
-/* Write a declared property. Default (flags == 0) matches
- * ReflectionProperty::setRawValue: bypass set hooks, type-check, preserve
- * readonly. Flags:
- *  - DEEPCLONE_HYDRATE_CALL_HOOKS: setValue semantics — invoke set hooks.
- *  - DEEPCLONE_HYDRATE_NO_LAZY_INIT: setRawValueWithoutLazyInitialization —
- *    skip lazy-init on the target slot; realize the object when the last
- *    lazy property is initialized. Delegates to ReflectionProperty.
- *
- * Dispatch:
- *  - Non-typed, non-hooked: direct slot write (fast path, dtor-safe).
- *  - Typed non-hooked: zend_update_property_ex (engine type-checks).
- *  - Hooked non-virtual (default): invoke the set-hook trampoline. The
- *    trampoline's execute_data->func carries prop_info, so the recursion
- *    check inside zend_std_write_property short-circuits to the direct
- *    backing write, bypassing the user set hook while still type-checking.
- *  - Hooked non-virtual (CALL_HOOKS): zend_update_property_ex — hook invoked.
- *  - NO_LAZY_INIT (any prop shape): delegate to ReflectionProperty.
- *
- * Caller must have verified dc_is_backed_declared_property(pi). Returns false
- * if a TypeError (or any exception) was raised by the engine. */
+/* Default dispatch matches ReflectionProperty::setRawValue. The non-obvious branch
+ * is the hook trampoline path: zend_std_write_property's recursion check sees
+ * prop_info on execute_data->func and short-circuits to the backing write,
+ * bypassing the user set hook while keeping the type-check.
+ * Caller must have verified dc_is_backed_declared_property(pi). */
 static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 	zend_string *name, zval *value, zend_long flags)
 {
-	bool call_hooks   = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
 #if PHP_VERSION_ID >= 80400
+	bool call_hooks   = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
 	bool no_lazy_init = (flags & DEEPCLONE_HYDRATE_NO_LAZY_INIT) != 0;
 #endif
 	zval *slot = OBJ_PROP(obj, pi->offset);
 
-	/* Readonly same-value skip: avoid the engine's "Cannot modify readonly
-	 * property" on an idempotent hydrate. Readonly and hooks are XOR, so
-	 * we don't need to worry about the trampoline path here. */
+	/* Idempotent readonly write — readonly and hooks are XOR, so no trampoline concern. */
 	if ((pi->flags & ZEND_ACC_READONLY)
 		&& Z_TYPE_P(slot) != IS_UNDEF
 		&& !(Z_PROP_FLAG_P(slot) & IS_PROP_UNINIT)
@@ -771,13 +747,8 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		return true;
 	}
 
-	/* null into a non-nullable typed slot: unset instead of raising
-	 * TypeError. Restores the "uninitialized typed" state that would
-	 * otherwise be unreachable via hydration. Hooked properties are
-	 * excluded outright (no backing slot to "unset" semantically, plus
-	 * a set hook may legitimately handle null) — gate is per-prop, so
-	 * non-hooked typed props in a CALL_HOOKS-mode hydrate still get the
-	 * forgiving treatment. */
+	/* null → uninitialized for non-nullable typed slots; hooked props excluded
+	 * (no backing slot to "unset", and the set hook may handle null itself). */
 	if (Z_TYPE_P(value) == IS_NULL
 		&& ZEND_TYPE_IS_SET(pi->type)
 		&& !ZEND_TYPE_ALLOW_NULL(pi->type)
@@ -796,10 +767,7 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 	}
 
 #if PHP_VERSION_ID >= 80100
-	/* Backed-enum cast: when pi is a single-class typed property referring
-	 * to a backed enum and the incoming value is a scalar (int|string),
-	 * substitute the corresponding enum case via Enum::from() semantics.
-	 * Property type only — hook presence and CALL_HOOKS don't change it. */
+	/* Property-type-only decision: hook presence and CALL_HOOKS don't influence it. */
 	zval enum_holder;
 	bool enum_holder_used = false;
 	if ((Z_TYPE_P(value) == IS_LONG || Z_TYPE_P(value) == IS_STRING)
@@ -811,10 +779,7 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		if (type_ce && (type_ce->ce_flags & ZEND_ACC_ENUM)
 			&& type_ce->enum_backing_type != IS_UNDEF)
 		{
-			/* Delegate to Enum::from() for full parity with the polyfill —
-			 * raises TypeError on int-backed + string, ValueError on unknown
-			 * backing values, and coerces int → string for string-backed
-			 * enums (per Enum::from()'s param-parsing rules). */
+			/* Enum::from() for parity with polyfill: standard TypeError/ValueError, scalar coercion. */
 			ZVAL_UNDEF(&enum_holder);
 			zend_call_method_with_1_params(NULL, type_ce, NULL, "from",
 				&enum_holder, value);
@@ -828,11 +793,7 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 #endif
 
 #if PHP_VERSION_ID >= 80400
-	/* Fast path: NO_LAZY_INIT only matters when the object is a lazy ghost
-	 * or proxy with at least one uninitialized lazy property. Otherwise the
-	 * default write path produces identical results without paying for the
-	 * Reflection round-trip. zend_lazy_object_initialized is a header-resident
-	 * static inline, so it's free to call. */
+	/* Skip the Reflection round-trip when there's no lazy-init to skip. */
 	if (no_lazy_init && !zend_lazy_object_initialized(obj)) {
 		bool ok = dc_set_raw_value_without_lazy_init(obj, pi, name, value);
 #if PHP_VERSION_ID >= 80100
@@ -2953,26 +2914,30 @@ PHP_FUNCTION(deepclone_hydrate)
 {
 	zend_object *obj_arg = NULL;
 	zend_string *class_name = NULL;
-	HashTable *scoped_props = NULL;
-	HashTable *mangled_vars = NULL;
+	HashTable *vars = NULL;
 	zend_long flags = 0;
 
-	ZEND_PARSE_PARAMETERS_START(1, 4)
+	ZEND_PARSE_PARAMETERS_START(1, 3)
 		Z_PARAM_OBJ_OR_STR(obj_arg, class_name)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_ARRAY_HT(scoped_props)
-		Z_PARAM_ARRAY_HT(mangled_vars)
+		Z_PARAM_ARRAY_HT(vars)
 		Z_PARAM_LONG(flags)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (UNEXPECTED(flags & ~(zend_long) DEEPCLONE_HYDRATE_FLAGS_MASK)) {
-		zend_value_error("deepclone_hydrate(): Argument #4 ($flags) contains unknown bits");
+		zend_value_error("deepclone_hydrate(): Argument #3 ($flags) contains unknown bits");
 		RETURN_THROWS();
 	}
 	if (UNEXPECTED((flags & DEEPCLONE_HYDRATE_CALL_HOOKS) && (flags & DEEPCLONE_HYDRATE_NO_LAZY_INIT))) {
-		zend_value_error("deepclone_hydrate(): Argument #4 ($flags) DEEPCLONE_HYDRATE_CALL_HOOKS and DEEPCLONE_HYDRATE_NO_LAZY_INIT are mutually exclusive");
+		zend_value_error("deepclone_hydrate(): Argument #3 ($flags) DEEPCLONE_HYDRATE_CALL_HOOKS and DEEPCLONE_HYDRATE_NO_LAZY_INIT are mutually exclusive");
 		RETURN_THROWS();
 	}
+
+	/* In MANGLED_VARS mode $vars is a flat mangled-key array (the shape
+	 * (array) $obj produces). Otherwise it's the scoped per-class shape. */
+	bool mangled_vars_mode = (flags & DEEPCLONE_HYDRATE_MANGLED_VARS) != 0;
+	HashTable *scoped_props = mangled_vars_mode ? NULL : vars;
+	HashTable *mangled_vars = mangled_vars_mode ? vars : NULL;
 
 	zval obj_zval;
 
@@ -3079,7 +3044,7 @@ PHP_FUNCTION(deepclone_hydrate)
 		zval *prop_val;
 		ZEND_HASH_FOREACH_STR_KEY_VAL(mangled_vars, prop_key, prop_val) {
 			if (UNEXPECTED(!prop_key)) {
-				zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) must have only string keys");
+				zend_value_error("deepclone_hydrate(): Argument #2 ($vars) in MANGLED_VARS mode must have only string keys");
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
 				zval_ptr_dtor(&obj_zval);
 				RETURN_THROWS();
@@ -3102,7 +3067,7 @@ PHP_FUNCTION(deepclone_hydrate)
 				/* Find second \0 separator */
 				const char *sep = memchr(key + 1, '\0', key_len - 1);
 				if (!sep || sep == key + 1) {
-					zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) contains an invalid mangled key");
+					zend_value_error("deepclone_hydrate(): Argument #2 ($vars) in MANGLED_VARS mode contains an invalid mangled key");
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
 					zval_ptr_dtor(&obj_zval);
 					RETURN_THROWS();
@@ -3112,7 +3077,7 @@ PHP_FUNCTION(deepclone_hydrate)
 
 				/* Reject embedded NUL in the property name portion */
 				if (UNEXPECTED(memchr(sep + 1, '\0', name_len) != NULL)) {
-					zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) contains an invalid mangled key");
+					zend_value_error("deepclone_hydrate(): Argument #2 ($vars) in MANGLED_VARS mode contains an invalid mangled key");
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
 					zval_ptr_dtor(&obj_zval);
 					RETURN_THROWS();
@@ -3156,7 +3121,7 @@ add_to_scope:
 				scope_bucket = zend_hash_update(scoped_props, scope_str, &new_arr);
 			}
 			if (UNEXPECTED(Z_TYPE_P(scope_bucket) != IS_ARRAY)) {
-				zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) value for scope \"%s\" must be of type array, %s given",
+				zend_value_error("deepclone_hydrate(): Argument #2 ($vars) value for scope \"%s\" must be of type array, %s given",
 					ZSTR_VAL(scope_str), zend_zval_value_name(scope_bucket));
 				if (real_name && real_name != prop_key) zend_string_release(real_name);
 				if (key_len > 2 && key[0] == '\0' && key[1] != '*') {
@@ -3197,14 +3162,22 @@ add_to_scope:
 	zval *scope_props;
 	ZEND_HASH_FOREACH_STR_KEY_VAL(scoped_props, scope_name, scope_props) {
 		if (UNEXPECTED(!scope_name)) {
-			zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) must have only string keys");
+			zend_value_error("deepclone_hydrate(): Argument #2 ($vars) must have only string keys");
 			if (scoped_owned) zval_ptr_dtor(&local_scoped);
 			zval_ptr_dtor(&obj_zval);
 			RETURN_THROWS();
 		}
 		if (UNEXPECTED(Z_TYPE_P(scope_props) != IS_ARRAY)) {
-			zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) must have only array values, %s given for key \"%s\"",
+			zend_value_error("deepclone_hydrate(): Argument #2 ($vars) must have only array values, %s given for key \"%s\"",
 				zend_zval_value_name(scope_props), ZSTR_VAL(scope_name));
+			if (scoped_owned) zval_ptr_dtor(&local_scoped);
+			zval_ptr_dtor(&obj_zval);
+			RETURN_THROWS();
+		}
+		/* Footgun: NUL-prefixed scope key almost certainly means a missing DEEPCLONE_HYDRATE_MANGLED_VARS flag. */
+		if (UNEXPECTED(ZSTR_VAL(scope_name)[0] == '\0')) {
+			zend_value_error("deepclone_hydrate(): Argument #2 ($vars) contains a NUL-prefixed key — "
+				"pass DEEPCLONE_HYDRATE_MANGLED_VARS in the $flags argument to interpret $vars as a flat mangled-key array");
 			if (scoped_owned) zval_ptr_dtor(&local_scoped);
 			zval_ptr_dtor(&obj_zval);
 			RETURN_THROWS();
@@ -3227,7 +3200,7 @@ add_to_scope:
 				p = p->parent;
 			}
 			if (UNEXPECTED(!scope_ce)) {
-				zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" is not a parent of \"%s\"",
+				zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" is not a parent of \"%s\"",
 					ZSTR_VAL(scope_name), ZSTR_VAL(obj_ce->name));
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
 				zval_ptr_dtor(&obj_zval);
@@ -3248,7 +3221,7 @@ add_to_scope:
 		zval *prop_val;
 		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(scope_props), prop_name, prop_val) {
 			if (UNEXPECTED(!prop_name)) {
-				zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" must have only string keys",
+				zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" must have only string keys",
 					ZSTR_VAL(scope_name));
 				EG(fake_scope) = old_scope;
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
@@ -3259,7 +3232,7 @@ add_to_scope:
 			/* "\0" key = internal state for ArrayObject/ArrayIterator/SplObjectStorage */
 			if (ZSTR_LEN(prop_name) == 1 && ZSTR_VAL(prop_name)[0] == '\0') {
 				if (UNEXPECTED(Z_TYPE_P(prop_val) != IS_ARRAY)) {
-					zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" special \"\\0\" value must be of type array, %s given",
+					zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" special \"\\0\" value must be of type array, %s given",
 						ZSTR_VAL(scope_name), zend_zval_value_name(prop_val));
 					EG(fake_scope) = old_scope;
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
@@ -3311,7 +3284,7 @@ add_to_scope:
 
 			if (obj_ce == zend_standard_class_def) {
 				if (UNEXPECTED(memchr(ZSTR_VAL(prop_name), '\0', ZSTR_LEN(prop_name)) != NULL)) {
-					zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" contains an invalid property name; "
+					zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" contains an invalid property name; "
 						"use bare property names in $scoped_vars, or pass mangled keys via $mangled_vars",
 						ZSTR_VAL(scope_name));
 					EG(fake_scope) = old_scope;
@@ -3343,7 +3316,7 @@ add_to_scope:
 				} else {
 					/* Fallback: dynamic property or unknown name — validate first */
 					if (UNEXPECTED(memchr(ZSTR_VAL(prop_name), '\0', ZSTR_LEN(prop_name)) != NULL)) {
-						zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" contains an invalid property name; "
+						zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" contains an invalid property name; "
 							"use bare property names in $scoped_vars, or pass mangled keys via $mangled_vars",
 							ZSTR_VAL(scope_name));
 						EG(fake_scope) = old_scope;

--- a/deepclone.c
+++ b/deepclone.c
@@ -716,6 +716,38 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		return true;
 	}
 
+#if PHP_VERSION_ID >= 80100
+	/* Backed-enum cast: when pi is a single-class typed property referring
+	 * to a backed enum and the incoming value is a scalar (int|string),
+	 * substitute the corresponding enum case via Enum::from() semantics.
+	 * Property type only — hook presence and CALL_HOOKS don't change it. */
+	zval enum_holder;
+	bool enum_holder_used = false;
+	if ((Z_TYPE_P(value) == IS_LONG || Z_TYPE_P(value) == IS_STRING)
+		&& ZEND_TYPE_HAS_NAME(pi->type)
+		&& !ZEND_TYPE_HAS_LIST(pi->type))
+	{
+		zend_class_entry *type_ce = zend_lookup_class_ex(
+			ZEND_TYPE_NAME(pi->type), NULL, ZEND_FETCH_CLASS_NO_AUTOLOAD);
+		if (type_ce && (type_ce->ce_flags & ZEND_ACC_ENUM)
+			&& type_ce->enum_backing_type != IS_UNDEF)
+		{
+			/* Delegate to Enum::from() for full parity with the polyfill —
+			 * raises TypeError on int-backed + string, ValueError on unknown
+			 * backing values, and coerces int → string for string-backed
+			 * enums (per Enum::from()'s param-parsing rules). */
+			ZVAL_UNDEF(&enum_holder);
+			zend_call_method_with_1_params(NULL, type_ce, NULL, "from",
+				&enum_holder, value);
+			if (UNEXPECTED(EG(exception))) {
+				return false;
+			}
+			value = &enum_holder;
+			enum_holder_used = true;
+		}
+	}
+#endif
+
 	if (!ZEND_TYPE_IS_SET(pi->type) && !DC_PROP_HAS_HOOKS(pi)) {
 		/* Move the old value out before running its destructor: a __destruct
 		 * on the old value can legitimately read (or reassign) this same slot.
@@ -736,6 +768,11 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		zend_update_property_ex(pi->ce, obj, name, value);
 	}
 
+#if PHP_VERSION_ID >= 80100
+	if (enum_holder_used) {
+		zval_ptr_dtor(&enum_holder);
+	}
+#endif
 	return !EG(exception);
 }
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -681,6 +681,17 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 	bool call_hooks = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
 	zval *slot = OBJ_PROP(obj, pi->offset);
 
+	/* Readonly same-value skip: avoid the engine's "Cannot modify readonly
+	 * property" on an idempotent hydrate. Readonly and hooks are XOR, so
+	 * we don't need to worry about the trampoline path here. */
+	if ((pi->flags & ZEND_ACC_READONLY)
+		&& Z_TYPE_P(slot) != IS_UNDEF
+		&& !(Z_PROP_FLAG_P(slot) & IS_PROP_UNINIT)
+		&& zend_is_identical(slot, value))
+	{
+		return true;
+	}
+
 	if (!ZEND_TYPE_IS_SET(pi->type) && !DC_PROP_HAS_HOOKS(pi)) {
 		/* Move the old value out before running its destructor: a __destruct
 		 * on the old value can legitimately read (or reassign) this same slot.

--- a/deepclone.c
+++ b/deepclone.c
@@ -128,6 +128,17 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
 # ifndef IS_HOOKED_PROPERTY_OFFSET
 #  define IS_HOOKED_PROPERTY_OFFSET(offset) (0)
 # endif
+/* ZEND_ACC_UNINSTANTIABLE composite landed in PHP 8.4. The bitmask is
+ * identical across versions; expand explicitly on 8.2/8.3. */
+# ifndef ZEND_ACC_UNINSTANTIABLE
+#  define ZEND_ACC_UNINSTANTIABLE (\
+	ZEND_ACC_INTERFACE | \
+	ZEND_ACC_TRAIT | \
+	ZEND_ACC_IMPLICIT_ABSTRACT_CLASS | \
+	ZEND_ACC_EXPLICIT_ABSTRACT_CLASS | \
+	ZEND_ACC_ENUM \
+)
+# endif
 #endif
 
 /* The stub-generated header relies on the compat shims above (specifically
@@ -633,14 +644,19 @@ static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)
 static zend_always_inline void dc_write_property_slot(zend_object *obj, zend_property_info *pi, zval *value)
 {
 	zval *slot = OBJ_PROP(obj, pi->offset);
-	if (Z_ISREF_P(slot) && ZEND_TYPE_IS_SET(pi->type)) {
-		ZEND_REF_DEL_TYPE_SOURCE(Z_REF_P(slot), pi);
+	/* Move the old value out before running its destructor: a __destruct on
+	 * the old value can legitimately read (or even reassign) this same slot.
+	 * Install the new value first so reentrant reads see a valid, typed slot. */
+	zval old;
+	ZVAL_COPY_VALUE(&old, slot);
+	if (Z_ISREF(old) && ZEND_TYPE_IS_SET(pi->type)) {
+		ZEND_REF_DEL_TYPE_SOURCE(Z_REF(old), pi);
 	}
-	zval_ptr_dtor(slot);
 	ZVAL_COPY(slot, value);
 	if (Z_ISREF_P(slot) && ZEND_TYPE_IS_SET(pi->type)) {
 		ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(slot), pi);
 	}
+	zval_ptr_dtor(&old);
 }
 
 /* ── Core traversal ─────────────────────────────────────────── */
@@ -1776,7 +1792,7 @@ PHP_FUNCTION(deepclone_to_array)
 	if (UNEXPECTED(Z_TYPE_P(value) == IS_RESOURCE)) {
 		zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 			"%s resource", zend_rsrc_list_get_rsrc_type(Z_RES_P(value)));
-		return;
+		RETURN_THROWS();
 	}
 
 	/* Static values: return ['value' => $value] */
@@ -2719,46 +2735,50 @@ cleanup:
 
 PHP_FUNCTION(deepclone_hydrate)
 {
-	zval *object_or_class;
+	zend_object *obj_arg = NULL;
+	zend_string *class_name = NULL;
 	HashTable *scoped_props = NULL;
 	HashTable *mangled_vars = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
-		Z_PARAM_ZVAL(object_or_class)
+		Z_PARAM_OBJ_OR_STR(obj_arg, class_name)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_ARRAY_HT(scoped_props)
 		Z_PARAM_ARRAY_HT(mangled_vars)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zval obj_zval;
-	bool created = false;
 
-	if (EXPECTED(Z_TYPE_P(object_or_class) == IS_OBJECT)) {
-		ZVAL_COPY(&obj_zval, object_or_class);
-	} else if (EXPECTED(Z_TYPE_P(object_or_class) == IS_STRING)) {
-		zend_class_entry *ce = zend_lookup_class(Z_STR_P(object_or_class));
+	if (EXPECTED(obj_arg)) {
+		ZVAL_OBJ_COPY(&obj_zval, obj_arg);
+	} else {
+		zend_class_entry *ce = zend_lookup_class(class_name);
 		if (UNEXPECTED(!ce)) {
 			zend_throw_exception_ex(dc_ce_class_not_found_exception, 0,
-				"Class \"%s\" not found.", Z_STRVAL_P(object_or_class));
-			return;
+				"Class \"%s\" not found.", ZSTR_VAL(class_name));
+			RETURN_THROWS();
 		}
 		if (UNEXPECTED(ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS|ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_ENUM))) {
 			zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 				"Class \"%s\" is not instantiable.", ZSTR_VAL(ce->name));
-			return;
+			RETURN_THROWS();
 		}
 		/* Reject classes that cannot function without their constructor,
 		 * using the same rules as dc_get_class_info / deepclone_from_array.
 		 * User classes always pass; internal classes are checked and cached. */
 		if (UNEXPECTED(ce->type == ZEND_INTERNAL_CLASS)) {
-			/* Per-thread cache (via module globals). Initialized in GINIT. */
+			/* Per-thread cache (via module globals). Packs ce pointer + ok-bit
+			 * into the stored value: low bit is ok, high bits are the ce. A ce
+			 * mismatch means the entry is stale (e.g. shared extension reloaded
+			 * the class between requests) — recompute. */
 			HashTable *hydrate_cache = &DC_G(hydrate_cache);
-			zval *cached = zend_hash_find_known_hash(hydrate_cache, ce->name);
-			if (EXPECTED(cached)) {
-				if (UNEXPECTED(!Z_LVAL_P(cached))) {
+			uintptr_t packed = (uintptr_t) zend_hash_find_ptr(hydrate_cache, ce->name);
+			zend_class_entry *cached_ce = (zend_class_entry *) (packed & ~(uintptr_t) 1);
+			if (EXPECTED(cached_ce == ce)) {
+				if (UNEXPECTED(!(packed & 1))) {
 					zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 						"Class \"%s\" is not instantiable.", ZSTR_VAL(ce->name));
-					return;
+					RETURN_THROWS();
 				}
 			} else {
 				bool ok = true;
@@ -2791,24 +2811,19 @@ PHP_FUNCTION(deepclone_hydrate)
 						ok = false;
 					}
 				}
-				zval zok;
-				ZVAL_LONG(&zok, ok ? 1 : 0);
-				zend_hash_add_new(hydrate_cache, ce->name, &zok);
+				packed = (uintptr_t) ce | (ok ? 1 : 0);
+				zend_hash_update_ptr(hydrate_cache, ce->name, (void *) packed);
 				if (!ok) {
 					zend_throw_exception_ex(dc_ce_not_instantiable_exception, 0,
 						"Class \"%s\" is not instantiable.", ZSTR_VAL(ce->name));
-					return;
+					RETURN_THROWS();
 				}
 			}
 		}
 		if (UNEXPECTED(object_init_ex(&obj_zval, ce) != SUCCESS)) {
-			return;
+			RETURN_THROWS();
 		}
-		created = true;
-	} else {
-		zend_type_error("deepclone_hydrate(): Argument #1 ($object_or_class) must be of type object|string, %s given",
-			zend_zval_value_name(object_or_class));
-		return;
+
 	}
 
 	/* Resolve $mangled_vars (flat mangled-key array) into scoped_props.
@@ -2839,8 +2854,8 @@ PHP_FUNCTION(deepclone_hydrate)
 			if (UNEXPECTED(!prop_key)) {
 				zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) must have only string keys");
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
-				if (created) zval_ptr_dtor(&obj_zval);
-				return;
+				zval_ptr_dtor(&obj_zval);
+				RETURN_THROWS();
 			}
 
 			const char *key = ZSTR_VAL(prop_key);
@@ -2862,21 +2877,20 @@ PHP_FUNCTION(deepclone_hydrate)
 				if (!sep || sep == key + 1) {
 					zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) contains an invalid mangled key");
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
-					if (created) zval_ptr_dtor(&obj_zval);
-					return;
+					zval_ptr_dtor(&obj_zval);
+					RETURN_THROWS();
 				}
 				size_t class_len = sep - (key + 1);
 				size_t name_len = key_len - class_len - 2;
-				real_name = zend_string_init(sep + 1, name_len, 0);
 
 				/* Reject embedded NUL in the property name portion */
 				if (UNEXPECTED(memchr(sep + 1, '\0', name_len) != NULL)) {
-					zend_string_release(real_name);
 					zend_value_error("deepclone_hydrate(): Argument #3 ($mangled_vars) contains an invalid mangled key");
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
-					if (created) zval_ptr_dtor(&obj_zval);
-					return;
+					zval_ptr_dtor(&obj_zval);
+					RETURN_THROWS();
 				}
+				real_name = zend_string_init(sep + 1, name_len, 0);
 
 				if (class_len == 1 && key[1] == '*') {
 					/* Protected: "\0*\0propName" — find declaring class */
@@ -2914,12 +2928,16 @@ add_to_scope:
 				array_init(&new_arr);
 				scope_bucket = zend_hash_update(scoped_props, scope_str, &new_arr);
 			}
-			if (Z_TYPE_P(scope_bucket) != IS_ARRAY) {
+			if (UNEXPECTED(Z_TYPE_P(scope_bucket) != IS_ARRAY)) {
+				zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) value for scope \"%s\" must be of type array, %s given",
+					ZSTR_VAL(scope_str), zend_zval_value_name(scope_bucket));
 				if (real_name && real_name != prop_key) zend_string_release(real_name);
 				if (key_len > 2 && key[0] == '\0' && key[1] != '*') {
 					zend_string_release(scope_str);
 				}
-				continue;
+				if (scoped_owned) zval_ptr_dtor(&local_scoped);
+				zval_ptr_dtor(&obj_zval);
+				RETURN_THROWS();
 			}
 			SEPARATE_ARRAY(scope_bucket);
 			zend_string *name_to_use = real_name ? real_name : prop_key;
@@ -2952,14 +2970,17 @@ add_to_scope:
 	zval *scope_props;
 	ZEND_HASH_FOREACH_STR_KEY_VAL(scoped_props, scope_name, scope_props) {
 		if (UNEXPECTED(!scope_name)) {
-			continue;
+			zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) must have only string keys");
+			if (scoped_owned) zval_ptr_dtor(&local_scoped);
+			zval_ptr_dtor(&obj_zval);
+			RETURN_THROWS();
 		}
 		if (UNEXPECTED(Z_TYPE_P(scope_props) != IS_ARRAY)) {
 			zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) must have only array values, %s given for key \"%s\"",
 				zend_zval_value_name(scope_props), ZSTR_VAL(scope_name));
 			if (scoped_owned) zval_ptr_dtor(&local_scoped);
-			if (created) zval_ptr_dtor(&obj_zval);
-			return;
+			zval_ptr_dtor(&obj_zval);
+			RETURN_THROWS();
 		}
 
 		/* Resolve scope class entry — must be obj_ce, a parent class, or stdClass.
@@ -2982,8 +3003,8 @@ add_to_scope:
 				zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" is not a parent of \"%s\"",
 					ZSTR_VAL(scope_name), ZSTR_VAL(obj_ce->name));
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
-				if (created) zval_ptr_dtor(&obj_zval);
-				return;
+				zval_ptr_dtor(&obj_zval);
+				RETURN_THROWS();
 			}
 		}
 
@@ -3004,13 +3025,20 @@ add_to_scope:
 					ZSTR_VAL(scope_name));
 				EG(fake_scope) = old_scope;
 				if (scoped_owned) zval_ptr_dtor(&local_scoped);
-				if (created) zval_ptr_dtor(&obj_zval);
-				return;
+				zval_ptr_dtor(&obj_zval);
+				RETURN_THROWS();
 			}
 
 			/* "\0" key = internal state for ArrayObject/ArrayIterator/SplObjectStorage */
 			if (ZSTR_LEN(prop_name) == 1 && ZSTR_VAL(prop_name)[0] == '\0') {
-				if (Z_TYPE_P(prop_val) != IS_ARRAY) continue;
+				if (UNEXPECTED(Z_TYPE_P(prop_val) != IS_ARRAY)) {
+					zend_value_error("deepclone_hydrate(): Argument #2 ($scoped_vars) scope \"%s\" special \"\\0\" value must be of type array, %s given",
+						ZSTR_VAL(scope_name), zend_zval_value_name(prop_val));
+					EG(fake_scope) = old_scope;
+					if (scoped_owned) zval_ptr_dtor(&local_scoped);
+					zval_ptr_dtor(&obj_zval);
+					RETURN_THROWS();
+				}
 
 				if (instanceof_function(obj_ce, spl_ce_SplObjectStorage)) {
 					/* [$obj1, $info1, $obj2, $info2, ...] → offsetSet(obj, info) */
@@ -3023,8 +3051,8 @@ add_to_scope:
 						if (UNEXPECTED(EG(exception))) {
 							EG(fake_scope) = old_scope;
 							if (scoped_owned) zval_ptr_dtor(&local_scoped);
-							if (created) zval_ptr_dtor(&obj_zval);
-							return;
+							zval_ptr_dtor(&obj_zval);
+							RETURN_THROWS();
 						}
 					}
 				} else if (instanceof_function(obj_ce, spl_ce_ArrayObject)
@@ -3046,8 +3074,8 @@ add_to_scope:
 						if (UNEXPECTED(EG(exception))) {
 							EG(fake_scope) = old_scope;
 							if (scoped_owned) zval_ptr_dtor(&local_scoped);
-							if (created) zval_ptr_dtor(&obj_zval);
-							return;
+							zval_ptr_dtor(&obj_zval);
+							RETURN_THROWS();
 						}
 					}
 				}
@@ -3061,8 +3089,8 @@ add_to_scope:
 						ZSTR_VAL(scope_name));
 					EG(fake_scope) = old_scope;
 					if (scoped_owned) zval_ptr_dtor(&local_scoped);
-					if (created) zval_ptr_dtor(&obj_zval);
-					return;
+					zval_ptr_dtor(&obj_zval);
+					RETURN_THROWS();
 				}
 				Z_TRY_ADDREF_P(prop_val);
 				zend_hash_update(obj->properties, prop_name, prop_val);
@@ -3087,15 +3115,15 @@ add_to_scope:
 							ZSTR_VAL(scope_name));
 						EG(fake_scope) = old_scope;
 						if (scoped_owned) zval_ptr_dtor(&local_scoped);
-						if (created) zval_ptr_dtor(&obj_zval);
+						zval_ptr_dtor(&obj_zval);
 						return;
 					}
 					zend_std_write_property(obj, prop_name, prop_val, NULL);
 					if (UNEXPECTED(EG(exception))) {
 						EG(fake_scope) = old_scope;
 						if (scoped_owned) zval_ptr_dtor(&local_scoped);
-						if (created) zval_ptr_dtor(&obj_zval);
-						return;
+						zval_ptr_dtor(&obj_zval);
+						RETURN_THROWS();
 					}
 				}
 			}

--- a/deepclone.c
+++ b/deepclone.c
@@ -147,6 +147,11 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
 # define DC_PROP_HAS_HOOKS(pi) (0)
 #endif
 
+/* Public flags for deepclone_hydrate()'s $flags parameter. Exported as
+ * PHP-level constants via deepclone.stub.php; values must match. */
+#define DEEPCLONE_HYDRATE_CALL_HOOKS    (1 << 0)
+#define DEEPCLONE_HYDRATE_FLAGS_MASK    (DEEPCLONE_HYDRATE_CALL_HOOKS)
+
 /* The stub-generated header relies on the compat shims above (specifically
  * zend_register_internal_class_with_flags on PHP < 8.4), so it has to be
  * included after this point. */
@@ -647,23 +652,36 @@ static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)
 		&& !(pi->flags & (ZEND_ACC_PROTECTED_SET | ZEND_ACC_PRIVATE_SET));
 }
 
-/* Write a declared property, matching ReflectionProperty::setRawValue semantics:
- *  - Non-typed, non-hooked: direct slot write (fast path, dtor-reentrancy safe).
- *  - Typed non-hooked: zend_update_property_ex with the declaring class as
- *    fake scope — engine type-checks (coerces under non-strict).
- *  - Hooked non-virtual: invoke the set-hook trampoline. The trampoline's
- *    execute_data->func carries prop_info, so the recursion check inside
- *    zend_std_write_property (zend_is_in_hook / zend_should_call_hook) short-
- *    circuits to the direct backing write, bypassing the user set hook while
- *    still type-checking. This is exactly what ReflectionProperty::setRawValue
- *    does.
+/* Write a declared property. Default (flags == 0) matches
+ * ReflectionProperty::setRawValue: bypass set hooks, type-check, preserve
+ * readonly. Flags:
+ *  - DEEPCLONE_HYDRATE_CALL_HOOKS: setValue semantics — invoke set hooks.
+ *
+ * Dispatch:
+ *  - Non-typed, non-hooked: direct slot write (fast path, dtor-safe).
+ *  - Typed non-hooked: zend_update_property_ex (engine type-checks).
+ *  - Hooked non-virtual (default): invoke the set-hook trampoline. The
+ *    trampoline's execute_data->func carries prop_info, so the recursion
+ *    check inside zend_std_write_property short-circuits to the direct
+ *    backing write, bypassing the user set hook while still type-checking.
+ *  - Hooked non-virtual (CALL_HOOKS): zend_update_property_ex — hook invoked.
+ *
+ * Lazy objects: writes go through the engine's standard path, which triggers
+ * the lazy initializer on first access (matching ReflectionProperty::setValue
+ * / setRawValue semantics). Suppressing initialization requires
+ * ReflectionProperty::setRawValueWithoutLazyInitialization, which depends on
+ * non-public engine APIs (zend_lazy_object_decr_lazy_props /
+ * zend_lazy_object_realize) that aren't available to shared extensions.
+ *
  * Caller must have verified dc_is_backed_declared_property(pi). Returns false
  * if a TypeError (or any exception) was raised by the engine. */
 static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
-	zend_string *name, zval *value)
+	zend_string *name, zval *value, zend_long flags)
 {
+	bool call_hooks = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
+	zval *slot = OBJ_PROP(obj, pi->offset);
+
 	if (!ZEND_TYPE_IS_SET(pi->type) && !DC_PROP_HAS_HOOKS(pi)) {
-		zval *slot = OBJ_PROP(obj, pi->offset);
 		/* Move the old value out before running its destructor: a __destruct
 		 * on the old value can legitimately read (or reassign) this same slot.
 		 * Install the new value first so reentrant reads see a valid slot. */
@@ -671,17 +689,18 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 		ZVAL_COPY_VALUE(&old, slot);
 		ZVAL_COPY(slot, value);
 		zval_ptr_dtor(&old);
-		return true;
 	}
 #if PHP_VERSION_ID >= 80400
-	if (DC_PROP_HAS_HOOKS(pi) && pi->hooks[ZEND_PROPERTY_HOOK_SET]) {
+	else if (!call_hooks && DC_PROP_HAS_HOOKS(pi) && pi->hooks[ZEND_PROPERTY_HOOK_SET]) {
 		zend_function *trampoline = zend_get_property_hook_trampoline(
 			pi, ZEND_PROPERTY_HOOK_SET, name);
 		zend_call_known_instance_method_with_1_params(trampoline, obj, NULL, value);
-		return !EG(exception);
 	}
 #endif
-	zend_update_property_ex(pi->ce, obj, name, value);
+	else {
+		zend_update_property_ex(pi->ce, obj, name, value);
+	}
+
 	return !EG(exception);
 }
 
@@ -2642,11 +2661,9 @@ PHP_FUNCTION(deepclone_from_array)
 							ZSTR_VAL(scope_name), ZSTR_VAL(prop_name), obj_id);
 					}
 					if (dc_is_backed_declared_property(use_pi)) {
-						/* setRawValue-style write: direct slot for non-typed
-						 * non-hooked (fast path), engine path otherwise — the
-						 * engine type-checks, bypasses set hooks on hooked
-						 * non-virtual, and tracks refs/type-sources. */
-						bool ok = dc_write_backed_property(obj, use_pi, prop_name, &final_val);
+						/* deepclone_from_array always uses setRawValue semantics
+						 * (flags=0): payload-driven, same policy as unserialize(). */
+						bool ok = dc_write_backed_property(obj, use_pi, prop_name, &final_val, 0);
 						zval_ptr_dtor(&final_val);
 						if (UNEXPECTED(!ok)) {
 							EG(fake_scope) = old_scope;
@@ -2770,13 +2787,20 @@ PHP_FUNCTION(deepclone_hydrate)
 	zend_string *class_name = NULL;
 	HashTable *scoped_props = NULL;
 	HashTable *mangled_vars = NULL;
+	zend_long flags = 0;
 
-	ZEND_PARSE_PARAMETERS_START(1, 3)
+	ZEND_PARSE_PARAMETERS_START(1, 4)
 		Z_PARAM_OBJ_OR_STR(obj_arg, class_name)
 		Z_PARAM_OPTIONAL
 		Z_PARAM_ARRAY_HT(scoped_props)
 		Z_PARAM_ARRAY_HT(mangled_vars)
+		Z_PARAM_LONG(flags)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if (UNEXPECTED(flags & ~(zend_long) DEEPCLONE_HYDRATE_FLAGS_MASK)) {
+		zend_value_error("deepclone_hydrate(): Argument #4 ($flags) contains unknown bits");
+		RETURN_THROWS();
+	}
 
 	zval obj_zval;
 
@@ -3137,7 +3161,7 @@ add_to_scope:
 					if (zv) pi = Z_PTR_P(zv);
 				}
 				if (dc_is_backed_declared_property(pi)) {
-					bool ok = dc_write_backed_property(obj, pi, prop_name, prop_val);
+					bool ok = dc_write_backed_property(obj, pi, prop_name, prop_val, flags);
 					if (UNEXPECTED(!ok)) {
 						EG(fake_scope) = old_scope;
 						if (scoped_owned) zval_ptr_dtor(&local_scoped);
@@ -3211,6 +3235,8 @@ PHP_MINIT_FUNCTION(deepclone)
 		register_class_DeepClone_NotInstantiableException(spl_ce_InvalidArgumentException);
 	dc_ce_class_not_found_exception =
 		register_class_DeepClone_ClassNotFoundException(spl_ce_InvalidArgumentException);
+
+	register_deepclone_symbols(module_number);
 
 	return SUCCESS;
 }

--- a/deepclone.stub.php
+++ b/deepclone.stub.php
@@ -23,9 +23,15 @@ namespace {
      */
     const DEEPCLONE_HYDRATE_NO_LAZY_INIT = UNKNOWN;
 
+    /**
+     * @var int
+     * @cvalue DEEPCLONE_HYDRATE_MANGLED_VARS
+     */
+    const DEEPCLONE_HYDRATE_MANGLED_VARS = UNKNOWN;
+
     function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array {}
 
     function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed {}
 
-    function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = [], int $flags = 0): object {}
+    function deepclone_hydrate(object|string $object_or_class, array $vars = [], int $flags = 0): object {}
 }

--- a/deepclone.stub.php
+++ b/deepclone.stub.php
@@ -11,9 +11,15 @@ namespace DeepClone {
 }
 
 namespace {
+    /**
+     * @var int
+     * @cvalue DEEPCLONE_HYDRATE_CALL_HOOKS
+     */
+    const DEEPCLONE_HYDRATE_CALL_HOOKS = UNKNOWN;
+
     function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array {}
 
     function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed {}
 
-    function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = []): object {}
+    function deepclone_hydrate(object|string $object_or_class, array $scoped_vars = [], array $mangled_vars = [], int $flags = 0): object {}
 }

--- a/deepclone.stub.php
+++ b/deepclone.stub.php
@@ -17,6 +17,12 @@ namespace {
      */
     const DEEPCLONE_HYDRATE_CALL_HOOKS = UNKNOWN;
 
+    /**
+     * @var int
+     * @cvalue DEEPCLONE_HYDRATE_NO_LAZY_INIT
+     */
+    const DEEPCLONE_HYDRATE_NO_LAZY_INIT = UNKNOWN;
+
     function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array {}
 
     function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed {}

--- a/deepclone_arginfo.h
+++ b/deepclone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit deepclone.stub.php instead.
- * Stub hash: c230b6f86caa038f9b54e91a1d5fff3b23ed0f2e */
+ * Stub hash: cc838592da0779d0068c308d771fd0d80e858102 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_to_array, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -32,6 +32,7 @@ static const zend_function_entry ext_functions[] = {
 static void register_deepclone_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_CALL_HOOKS", DEEPCLONE_HYDRATE_CALL_HOOKS, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_NO_LAZY_INIT", DEEPCLONE_HYDRATE_NO_LAZY_INIT, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class_DeepClone_NotInstantiableException(zend_class_entry *class_entry_InvalidArgumentException)

--- a/deepclone_arginfo.h
+++ b/deepclone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit deepclone.stub.php instead.
- * Stub hash: 6aeb61465f527b63ceb6109ecda8fbcb037879fc */
+ * Stub hash: c230b6f86caa038f9b54e91a1d5fff3b23ed0f2e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_to_array, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -15,6 +15,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_hydrate, 0, 1, IS_OBJE
 	ZEND_ARG_TYPE_MASK(0, object_or_class, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, scoped_vars, IS_ARRAY, 0, "[]")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mangled_vars, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(deepclone_to_array);
@@ -27,6 +28,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(deepclone_hydrate, arginfo_deepclone_hydrate)
 	ZEND_FE_END
 };
+
+static void register_deepclone_symbols(int module_number)
+{
+	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_CALL_HOOKS", DEEPCLONE_HYDRATE_CALL_HOOKS, CONST_PERSISTENT);
+}
 
 static zend_class_entry *register_class_DeepClone_NotInstantiableException(zend_class_entry *class_entry_InvalidArgumentException)
 {

--- a/deepclone_arginfo.h
+++ b/deepclone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit deepclone.stub.php instead.
- * Stub hash: cc838592da0779d0068c308d771fd0d80e858102 */
+ * Stub hash: 2383b81a7c575515337480af636d47f80d3c77f0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_to_array, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -13,8 +13,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_hydrate, 0, 1, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_MASK(0, object_or_class, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, scoped_vars, IS_ARRAY, 0, "[]")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mangled_vars, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, vars, IS_ARRAY, 0, "[]")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -33,6 +32,7 @@ static void register_deepclone_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_CALL_HOOKS", DEEPCLONE_HYDRATE_CALL_HOOKS, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_NO_LAZY_INIT", DEEPCLONE_HYDRATE_NO_LAZY_INIT, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_MANGLED_VARS", DEEPCLONE_HYDRATE_MANGLED_VARS, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class_DeepClone_NotInstantiableException(zend_class_entry *class_entry_InvalidArgumentException)

--- a/php_deepclone.h
+++ b/php_deepclone.h
@@ -8,6 +8,10 @@ extern zend_module_entry deepclone_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(deepclone)
 	HashTable hydrate_cache;
+	/* Per-request cache of pre-constructed ReflectionProperty instances, keyed
+	 * by zend_property_info pointer. Used to amortize the construction cost in
+	 * the DEEPCLONE_HYDRATE_NO_LAZY_INIT path. */
+	HashTable lazy_init_refl_cache;
 ZEND_END_MODULE_GLOBALS(deepclone)
 
 ZEND_EXTERN_MODULE_GLOBALS(deepclone)

--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -85,24 +85,24 @@ var_dump(count($ai) === 3);
 // === Mangled vars (3rd parameter) ===
 
 // stdClass with flat properties
-$o = deepclone_hydrate('stdClass', [], ['p' => 123]);
+$o = deepclone_hydrate('stdClass', ['p' => 123], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($o->p === 123);
 
 // Case-insensitive class name
-$o = deepclone_hydrate('STDcLASS', [], ['p' => 123]);
+$o = deepclone_hydrate('STDcLASS', ['p' => 123], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($o->p === 123);
 
-// ArrayObject via "\0" key in $mangled_vars
-$ao = deepclone_hydrate('ArrayObject', [], ["\0" => [[123]]]);
+// ArrayObject via "\0" key in mangled-vars mode
+$ao = deepclone_hydrate('ArrayObject', ["\0" => [[123]]], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($ao[0] === 123);
 
-// ArrayObject via "\0" key in $scoped_vars (own class as scope)
+// ArrayObject via "\0" key in scoped mode (own class as scope)
 $ao = deepclone_hydrate('ArrayObject', ['ArrayObject' => ["\0" => [[456]]]]);
 var_dump($ao[0] === 456);
 
-// SplObjectStorage via "\0" key in $mangled_vars
+// SplObjectStorage via "\0" key in mangled-vars mode
 $o1 = new stdClass();
-$s = deepclone_hydrate('SplObjectStorage', [], ["\0" => [$o1, 'data']]);
+$s = deepclone_hydrate('SplObjectStorage', ["\0" => [$o1, 'data']], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($s->count() === 1);
 
 // SplObjectStorage via "\0" key in $scoped_vars
@@ -110,11 +110,6 @@ $o1 = new stdClass();
 $s = deepclone_hydrate('SplObjectStorage', ['SplObjectStorage' => ["\0" => [$o1, 'info']]]);
 var_dump($s->count() === 1);
 
-// Inheritance with mixed $properties + $scopedProperties
-$actual = (array) deepclone_hydrate('Bar', [Foo::class => ['priv' => 234]], [
-    'dyn' => 456, 'ro' => 567, 'prot' => 345, 'priv' => 123,
-]);
-ksort($actual);
 $expected = [
     "\0*\0prot" => 345,
     "\0Bar\0priv" => 123,
@@ -122,21 +117,20 @@ $expected = [
     'dyn' => 456,
     'ro' => 567,
 ];
-var_dump($actual === $expected);
 
-// Mangled key format in $properties
-$actual = (array) deepclone_hydrate('Bar', [], [
+// Mangled key format
+$actual = (array) deepclone_hydrate('Bar', [
     "\0*\0prot" => 345,
     "\0Bar\0priv" => 123,
     "\0Foo\0priv" => 234,
     'dyn' => 456,
     'ro' => 567,
-]);
+], DEEPCLONE_HYDRATE_MANGLED_VARS);
 ksort($actual);
 var_dump($actual === $expected);
 
 // Exception trace (internal class hydration)
-$e = deepclone_hydrate('Exception', [], ['trace' => [234]]);
+$e = deepclone_hydrate('Exception', ['trace' => [234]], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($e->getTrace() === [234]);
 
 // Readonly: hydrating an already-initialized readonly property throws,
@@ -150,7 +144,7 @@ class ReadonlyClass {
 }
 $obj = new ReadonlyClass(123);
 try {
-    deepclone_hydrate($obj, [], ['value' => 456]);
+    deepclone_hydrate($obj, ['value' => 456], DEEPCLONE_HYDRATE_MANGLED_VARS);
     var_dump(false);
 } catch (\Error $e) {
     var_dump(str_contains($e->getMessage(), 'readonly'));
@@ -161,10 +155,10 @@ var_dump($obj->getValue() === 123);
 $obj = deepclone_hydrate('ReadonlyClass', ['ReadonlyClass' => ['value' => 456]]);
 var_dump($obj->getValue() === 456);
 
-// PHP references preservation
+// PHP references preservation (mangled mode keeps refs across the hydrate)
 $a = 1;
 $props = ['p1' => &$a, 'p2' => &$a];
-$obj = deepclone_hydrate('stdClass', [], $props);
+$obj = deepclone_hydrate('stdClass', $props, DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($obj->p1 === 1 && $obj->p2 === 1);
 $a = 2;
 var_dump($obj->p1 === 2 && $obj->p2 === 2);
@@ -180,15 +174,10 @@ class GP { private string $secret = ''; public function getSecret(): string { re
 class P extends GP { private int $mid = 0; public function getMid(): int { return $this->mid; } }
 class C extends P { public string $pub = ''; }
 
-$o = deepclone_hydrate('C', [], ["\0GP\0secret" => 'gp_val', "\0P\0mid" => 42, 'pub' => 'hi']);
+$o = deepclone_hydrate('C', ["\0GP\0secret" => 'gp_val', "\0P\0mid" => 42, 'pub' => 'hi'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($o->getSecret() === 'gp_val');
 var_dump($o->getMid() === 42);
 var_dump($o->pub === 'hi');
-
-// === Both $scopedProperties and $properties writing same property ===
-// $properties are resolved and merged into scopedProperties, overwriting same scope+name
-$o = deepclone_hydrate('stdClass', ['stdClass' => ['x' => 'from_scoped']], ['x' => 'from_flat']);
-var_dump($o->x === 'from_flat');
 
 // === Error cases ===
 
@@ -259,7 +248,7 @@ try {
 
 // Integer key in $mangled_vars → ValueError
 try {
-    deepclone_hydrate('stdClass', [], [0 => 'val']);
+    deepclone_hydrate('stdClass', [0 => 'val'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 } catch (\ValueError $e) {
     var_dump(str_contains($e->getMessage(), 'string keys'));
 }
@@ -280,7 +269,7 @@ try {
 
 // NUL byte in mangled key property portion → ValueError
 try {
-    deepclone_hydrate('stdClass', [], ["\0*\0foo\0bar" => 'val']);
+    deepclone_hydrate('stdClass', ["\0*\0foo\0bar" => 'val'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 } catch (\ValueError $e) {
     var_dump(str_contains($e->getMessage(), 'invalid mangled key'));
 }
@@ -329,8 +318,6 @@ var_dump($o instanceof stdClass);
 echo "Done\n";
 ?>
 --EXPECT--
-bool(true)
-bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -139,7 +139,9 @@ var_dump($actual === $expected);
 $e = deepclone_hydrate('Exception', [], ['trace' => [234]]);
 var_dump($e->getTrace() === [234]);
 
-// Readonly: direct slot write overwrites even initialized readonly
+// Readonly: hydrating an already-initialized readonly property throws,
+// matching ReflectionProperty::setRawValue semantics (engine checks
+// ZEND_ACC_READONLY during the write).
 class ReadonlyClass {
     public string $status = 'new';
     private readonly int $value;
@@ -147,9 +149,13 @@ class ReadonlyClass {
     public function getValue(): int { return $this->value; }
 }
 $obj = new ReadonlyClass(123);
-$obj = deepclone_hydrate($obj, [], ['value' => 456, 'status' => 'hydrated']);
-var_dump($obj->getValue() === 456);
-var_dump($obj->status === 'hydrated');
+try {
+    deepclone_hydrate($obj, [], ['value' => 456]);
+    var_dump(false);
+} catch (\Error $e) {
+    var_dump(str_contains($e->getMessage(), 'readonly'));
+}
+var_dump($obj->getValue() === 123);
 
 // Readonly: uninitialized → sets value
 $obj = deepclone_hydrate('ReadonlyClass', ['ReadonlyClass' => ['value' => 456]]);

--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -246,7 +246,7 @@ try {
 
 // Bad type
 try {
-    deepclone_hydrate(123, []);
+    deepclone_hydrate([], []);
 } catch (\TypeError $e) {
     var_dump(str_contains($e->getMessage(), 'must be of type object|string'));
 }

--- a/tests/deepclone_hydrate_dtor_reentrance.phpt
+++ b/tests/deepclone_hydrate_dtor_reentrance.phpt
@@ -1,0 +1,55 @@
+--TEST--
+deepclone_hydrate() survives a __destruct that reads the same property slot
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+// When the old value in a property slot has a __destruct that reads the
+// same property, it must observe the NEW value (slot is already replaced
+// before the dtor runs), not a half-freed zval.
+class Host
+{
+    public ?ReadsSlotOnDtor $slot = null;
+}
+
+class ReadsSlotOnDtor
+{
+    public static ?string $observed = null;
+    public string $tag = '';
+    public ?Host $back = null;
+
+    public function __destruct()
+    {
+        if ($this->back !== null) {
+            self::$observed = $this->back->slot?->tag ?? 'null';
+        }
+    }
+}
+
+$host = new Host();
+
+$old = new ReadsSlotOnDtor();
+$old->tag = 'old';
+$old->back = $host;
+$host->slot = $old;
+unset($old); // slot holds the only ref; next overwrite triggers dtor.
+
+$new = new ReadsSlotOnDtor();
+$new->tag = 'new';
+$new->back = $host;
+
+// Hydrate $host with slot = $new. The assignment frees the old object,
+// whose __destruct reads $host->slot. That read must observe $new, not
+// a freed zval.
+deepclone_hydrate($host, [Host::class => ['slot' => $new]]);
+
+var_dump($host->slot->tag === 'new');
+var_dump(ReadsSlotOnDtor::$observed === 'new');
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_hydrate_enum_cast.phpt
+++ b/tests/deepclone_hydrate_enum_cast.phpt
@@ -78,7 +78,7 @@ var_dump($o->s === Suit::Spades);
 
 // CALL_HOOKS gate is per-prop: non-hooked enum-typed props still get cast.
 $o = new WithEnum();
-$o = deepclone_hydrate($o, [WithEnum::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+$o = deepclone_hydrate($o, [WithEnum::class => ['s' => 'S']], DEEPCLONE_HYDRATE_CALL_HOOKS);
 var_dump($o->s === Suit::Spades);
 
 // Hooked enum prop under CALL_HOOKS: the cast decision is property-type
@@ -99,7 +99,7 @@ if (PHP_VERSION_ID >= 80400) {
         }
     }');
     $o = new WithHookedEnumWider();
-    $o = deepclone_hydrate($o, [WithHookedEnumWider::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+    $o = deepclone_hydrate($o, [WithHookedEnumWider::class => ['s' => 'S']], DEEPCLONE_HYDRATE_CALL_HOOKS);
     var_dump($o->s === Suit::Spades);
     var_dump(WithHookedEnumWider::$lastRaw === null);
 
@@ -109,7 +109,7 @@ if (PHP_VERSION_ID >= 80400) {
         }
     }');
     $o = new WithHookedEnumStrict();
-    $o = deepclone_hydrate($o, [WithHookedEnumStrict::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+    $o = deepclone_hydrate($o, [WithHookedEnumStrict::class => ['s' => 'S']], DEEPCLONE_HYDRATE_CALL_HOOKS);
     var_dump($o->s === Suit::Spades);
 } else {
     var_dump(true);

--- a/tests/deepclone_hydrate_enum_cast.phpt
+++ b/tests/deepclone_hydrate_enum_cast.phpt
@@ -1,0 +1,135 @@
+--TEST--
+deepclone_hydrate() casts string/int scalars to the corresponding backed-enum case
+--EXTENSIONS--
+deepclone
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80100) die('skip backed enums require PHP 8.1+');
+?>
+--FILE--
+<?php
+
+enum Suit: string { case Hearts = 'H'; case Spades = 'S'; }
+enum Size: int    { case Small = 1;   case Large = 2;   }
+enum Plain { case Alpha; } /* non-backed */
+
+class WithEnum
+{
+    public Suit $s = Suit::Hearts;
+    public ?Suit $ns = Suit::Hearts;
+    public Size $n = Size::Small;
+    public Plain $p = Plain::Alpha;
+}
+
+// String → string-backed enum
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['s' => 'S']]);
+var_dump($o->s === Suit::Spades);
+
+// Int → int-backed enum
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['n' => 2]]);
+var_dump($o->n === Size::Large);
+
+// Nullable enum + null → stored as null (no cast, unset rule doesn't fire either)
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['ns' => null]]);
+var_dump($o->ns === null);
+
+// Nullable enum + matching scalar → cast
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['ns' => 'S']]);
+var_dump($o->ns === Suit::Spades);
+
+// Cross-type scalar (int → string-backed enum): Enum::from() coerces the
+// int to its string form, then the lookup fails for an unknown value →
+// ValueError. Same path the polyfill takes via Enum::from($value).
+$o = new WithEnum();
+try {
+    deepclone_hydrate($o, [WithEnum::class => ['s' => 5]]);
+    var_dump(false);
+} catch (\ValueError $e) {
+    var_dump(str_contains($e->getMessage(), 'not a valid backing value for enum'));
+}
+
+// Unknown backing value: matches Enum::from() — ValueError ("X is not a
+// valid backing value for enum Suit").
+$o = new WithEnum();
+try {
+    deepclone_hydrate($o, [WithEnum::class => ['s' => 'X']]);
+    var_dump(false);
+} catch (\ValueError $e) {
+    var_dump(str_contains($e->getMessage(), 'not a valid backing value for enum'));
+}
+
+// Non-backed enum: no cast applied, engine TypeError on scalar
+$o = new WithEnum();
+try {
+    deepclone_hydrate($o, [WithEnum::class => ['p' => 'Alpha']]);
+    var_dump(false);
+} catch (\TypeError $e) {
+    var_dump(str_contains($e->getMessage(), 'Plain'));
+}
+
+// Passing the enum case directly still works (no cast needed)
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['s' => Suit::Spades]]);
+var_dump($o->s === Suit::Spades);
+
+// CALL_HOOKS gate is per-prop: non-hooked enum-typed props still get cast.
+$o = new WithEnum();
+$o = deepclone_hydrate($o, [WithEnum::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+var_dump($o->s === Suit::Spades);
+
+// Hooked enum prop under CALL_HOOKS: the cast decision is property-type
+// only — hook signature shape doesn't change it. Both strict and wider
+// hooks see the enum case (the wider hook's string branch never fires).
+if (PHP_VERSION_ID >= 80400) {
+    eval('class WithHookedEnumWider {
+        public static ?string $lastRaw = null;
+        public Suit $s = Suit::Hearts {
+            set(Suit|string $v) {
+                if (is_string($v)) {
+                    self::$lastRaw = "raw:".$v;
+                    $this->s = Suit::from($v);
+                } else {
+                    $this->s = $v;
+                }
+            }
+        }
+    }');
+    $o = new WithHookedEnumWider();
+    $o = deepclone_hydrate($o, [WithHookedEnumWider::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+    var_dump($o->s === Suit::Spades);
+    var_dump(WithHookedEnumWider::$lastRaw === null);
+
+    eval('class WithHookedEnumStrict {
+        public Suit $s = Suit::Hearts {
+            set(Suit $v) { $this->s = $v; }
+        }
+    }');
+    $o = new WithHookedEnumStrict();
+    $o = deepclone_hydrate($o, [WithHookedEnumStrict::class => ['s' => 'S']], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+    var_dump($o->s === Suit::Spades);
+} else {
+    var_dump(true);
+    var_dump(true);
+    var_dump(true);
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_hydrate_flags.phpt
+++ b/tests/deepclone_hydrate_flags.phpt
@@ -33,12 +33,20 @@ try {
     var_dump(str_contains($e->getMessage(), 'unknown bits'));
 }
 
-// Lazy ghost: hydrating via deepclone_hydrate writes through the engine's
-// standard path, which triggers the lazy initializer on first access (same
-// as ReflectionProperty::setValue / setRawValue). Hydrate-written values
-// then take precedence over what the initializer set.
+// Mutually exclusive flags → ValueError
+try {
+    deepclone_hydrate(HookedBacking::class, [], [], DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT);
+    var_dump(false);
+} catch (\ValueError $e) {
+    var_dump(str_contains($e->getMessage(), 'mutually exclusive'));
+}
+
+// Lazy ghost, default flag: hydrate triggers the lazy initializer on first
+// access (matching ReflectionProperty::setValue / setRawValue). The hydrate
+// value wins for the written prop; initializer values survive for the rest.
 class Lazy { public int $a = 0; public string $b = ''; }
 $rc = new ReflectionClass(Lazy::class);
+
 $initRan = 0;
 $ghost = $rc->newLazyGhost(function (Lazy $o) use (&$initRan) {
     ++$initRan;
@@ -46,13 +54,32 @@ $ghost = $rc->newLazyGhost(function (Lazy $o) use (&$initRan) {
     $o->b = 'init';
 });
 deepclone_hydrate($ghost, [Lazy::class => ['a' => 99]]);
-var_dump($initRan === 1);     // initializer ran
-var_dump($ghost->a === 99);   // hydrate value wins
-var_dump($ghost->b === 'init'); // initializer-set value preserved
+var_dump($initRan === 1);        // initializer ran once
+var_dump($ghost->a === 99);      // hydrate value wins
+var_dump($ghost->b === 'init');  // initializer value preserved
+
+// Lazy ghost, NO_LAZY_INIT: hydrate skips the initializer. After writing
+// the single lazy prop, the object is realized (no more lazy props).
+$initRan = 0;
+$ghost = $rc->newLazyGhost(function (Lazy $o) use (&$initRan) {
+    ++$initRan;
+    $o->a = 1;
+    $o->b = 'init';
+});
+deepclone_hydrate($ghost, [Lazy::class => ['a' => 99, 'b' => 'hyd']], [], DEEPCLONE_HYDRATE_NO_LAZY_INIT);
+var_dump($initRan === 0);        // initializer did NOT run
+var_dump($ghost->a === 99);
+var_dump($ghost->b === 'hyd');
+var_dump($initRan === 0);        // subsequent read still doesn't init (realized)
 
 echo "Done\n";
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/tests/deepclone_hydrate_flags.phpt
+++ b/tests/deepclone_hydrate_flags.phpt
@@ -1,0 +1,62 @@
+--TEST--
+deepclone_hydrate() $flags parameter: CALL_HOOKS / validation / lazy semantics
+--EXTENSIONS--
+deepclone
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80400) {
+    die('skip property hooks / lazy objects require PHP 8.4+');
+}
+?>
+--FILE--
+<?php
+
+class HookedBacking {
+    public int $x = 0 {
+        set(int $v) { $this->x = $v * 10; }
+    }
+}
+
+// Default (flags=0) → setRawValue: bypass hook
+$o = deepclone_hydrate(HookedBacking::class, [HookedBacking::class => ['x' => 7]]);
+var_dump($o->x === 7);
+
+// DEEPCLONE_HYDRATE_CALL_HOOKS → setValue: invoke hook
+$o = deepclone_hydrate(HookedBacking::class, [HookedBacking::class => ['x' => 7]], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+var_dump($o->x === 70);
+
+// Unknown bit → ValueError
+try {
+    deepclone_hydrate(HookedBacking::class, [], [], 1 << 30);
+    var_dump(false);
+} catch (\ValueError $e) {
+    var_dump(str_contains($e->getMessage(), 'unknown bits'));
+}
+
+// Lazy ghost: hydrating via deepclone_hydrate writes through the engine's
+// standard path, which triggers the lazy initializer on first access (same
+// as ReflectionProperty::setValue / setRawValue). Hydrate-written values
+// then take precedence over what the initializer set.
+class Lazy { public int $a = 0; public string $b = ''; }
+$rc = new ReflectionClass(Lazy::class);
+$initRan = 0;
+$ghost = $rc->newLazyGhost(function (Lazy $o) use (&$initRan) {
+    ++$initRan;
+    $o->a = 1;
+    $o->b = 'init';
+});
+deepclone_hydrate($ghost, [Lazy::class => ['a' => 99]]);
+var_dump($initRan === 1);     // initializer ran
+var_dump($ghost->a === 99);   // hydrate value wins
+var_dump($ghost->b === 'init'); // initializer-set value preserved
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_hydrate_flags.phpt
+++ b/tests/deepclone_hydrate_flags.phpt
@@ -22,12 +22,12 @@ $o = deepclone_hydrate(HookedBacking::class, [HookedBacking::class => ['x' => 7]
 var_dump($o->x === 7);
 
 // DEEPCLONE_HYDRATE_CALL_HOOKS → setValue: invoke hook
-$o = deepclone_hydrate(HookedBacking::class, [HookedBacking::class => ['x' => 7]], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+$o = deepclone_hydrate(HookedBacking::class, [HookedBacking::class => ['x' => 7]], DEEPCLONE_HYDRATE_CALL_HOOKS);
 var_dump($o->x === 70);
 
 // Unknown bit → ValueError
 try {
-    deepclone_hydrate(HookedBacking::class, [], [], 1 << 30);
+    deepclone_hydrate(HookedBacking::class, [], 1 << 30);
     var_dump(false);
 } catch (\ValueError $e) {
     var_dump(str_contains($e->getMessage(), 'unknown bits'));
@@ -35,7 +35,7 @@ try {
 
 // Mutually exclusive flags → ValueError
 try {
-    deepclone_hydrate(HookedBacking::class, [], [], DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT);
+    deepclone_hydrate(HookedBacking::class, [], DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT);
     var_dump(false);
 } catch (\ValueError $e) {
     var_dump(str_contains($e->getMessage(), 'mutually exclusive'));
@@ -66,7 +66,7 @@ $ghost = $rc->newLazyGhost(function (Lazy $o) use (&$initRan) {
     $o->a = 1;
     $o->b = 'init';
 });
-deepclone_hydrate($ghost, [Lazy::class => ['a' => 99, 'b' => 'hyd']], [], DEEPCLONE_HYDRATE_NO_LAZY_INIT);
+deepclone_hydrate($ghost, [Lazy::class => ['a' => 99, 'b' => 'hyd']], DEEPCLONE_HYDRATE_NO_LAZY_INIT);
 var_dump($initRan === 0);        // initializer did NOT run
 var_dump($ghost->a === 99);
 var_dump($ghost->b === 'hyd');

--- a/tests/deepclone_hydrate_mangled_validation.phpt
+++ b/tests/deepclone_hydrate_mangled_validation.phpt
@@ -10,7 +10,7 @@ class BadKeys {}
 function check_bad_key(string $key): bool
 {
     try {
-        deepclone_hydrate('BadKeys', [], [$key => 123]);
+        deepclone_hydrate('BadKeys', [$key => 123], DEEPCLONE_HYDRATE_MANGLED_VARS);
         return false;
     } catch (ValueError $e) {
         return str_contains($e->getMessage(), 'invalid mangled key');

--- a/tests/deepclone_hydrate_null_unset.phpt
+++ b/tests/deepclone_hydrate_null_unset.phpt
@@ -1,0 +1,52 @@
+--TEST--
+deepclone_hydrate() unsets non-nullable typed properties when given null
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+class Typed
+{
+    public int $x = 42;
+    public ?int $y = 7;
+    public mixed $m = 'foo';
+}
+
+// null into non-nullable typed → slot becomes uninitialized
+$o = new Typed();
+$o = deepclone_hydrate($o, [Typed::class => ['x' => null]]);
+var_dump((new ReflectionProperty(Typed::class, 'x'))->isInitialized($o));
+
+// Reading an uninitialized typed prop throws the standard engine error
+try {
+    $v = $o->x;
+    var_dump(false);
+} catch (\Error $e) {
+    var_dump(str_contains($e->getMessage(), 'must not be accessed before initialization'));
+}
+
+// null into nullable → stored as null
+$o = new Typed();
+$o = deepclone_hydrate($o, [Typed::class => ['y' => null]]);
+var_dump($o->y === null);
+
+// null into mixed → stored as null
+$o = new Typed();
+$o = deepclone_hydrate($o, [Typed::class => ['m' => null]]);
+var_dump($o->m === null);
+
+// CALL_HOOKS is per-prop: a non-hooked typed prop still gets unset, even
+// when the flag is set (no set hook on this property to defer to).
+$o = new Typed();
+$o = deepclone_hydrate($o, [Typed::class => ['x' => null]], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+var_dump((new ReflectionProperty(Typed::class, 'x'))->isInitialized($o));
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+Done

--- a/tests/deepclone_hydrate_null_unset.phpt
+++ b/tests/deepclone_hydrate_null_unset.phpt
@@ -38,7 +38,7 @@ var_dump($o->m === null);
 // CALL_HOOKS is per-prop: a non-hooked typed prop still gets unset, even
 // when the flag is set (no set hook on this property to defer to).
 $o = new Typed();
-$o = deepclone_hydrate($o, [Typed::class => ['x' => null]], [], DEEPCLONE_HYDRATE_CALL_HOOKS);
+$o = deepclone_hydrate($o, [Typed::class => ['x' => null]], DEEPCLONE_HYDRATE_CALL_HOOKS);
 var_dump((new ReflectionProperty(Typed::class, 'x'))->isInitialized($o));
 
 echo "Done\n";

--- a/tests/deepclone_hydrate_readonly_idempotent.phpt
+++ b/tests/deepclone_hydrate_readonly_idempotent.phpt
@@ -1,0 +1,63 @@
+--TEST--
+deepclone_hydrate() skips readonly writes when the new value is identical (===)
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+class ReadonlyInt
+{
+    public readonly int $v;
+    public function __construct(int $v) { $this->v = $v; }
+}
+
+class ReadonlyObj
+{
+    public readonly \stdClass $o;
+    public function __construct(\stdClass $o) { $this->o = $o; }
+}
+
+// Same value (===) → silently skipped
+$o = new ReadonlyInt(42);
+$o = deepclone_hydrate($o, [ReadonlyInt::class => ['v' => 42]]);
+var_dump($o->v === 42);
+
+// Different value → engine throws
+$o = new ReadonlyInt(42);
+try {
+    deepclone_hydrate($o, [ReadonlyInt::class => ['v' => 43]]);
+    var_dump(false);
+} catch (\Error $e) {
+    var_dump(str_contains($e->getMessage(), 'readonly'));
+}
+var_dump($o->v === 42);
+
+// Object identity (same zval) → skipped
+$inner = new \stdClass();
+$o = new ReadonlyObj($inner);
+$o = deepclone_hydrate($o, [ReadonlyObj::class => ['o' => $inner]]);
+var_dump($o->o === $inner);
+
+// Different object (even if equal) → engine throws
+$o = new ReadonlyObj(new \stdClass());
+try {
+    deepclone_hydrate($o, [ReadonlyObj::class => ['o' => new \stdClass()]]);
+    var_dump(false);
+} catch (\Error $e) {
+    var_dump(str_contains($e->getMessage(), 'readonly'));
+}
+
+// Uninitialized readonly → writes normally
+$o = deepclone_hydrate(ReadonlyInt::class, [ReadonlyInt::class => ['v' => 99]]);
+var_dump($o->v === 99);
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_hydrate_typed_props.phpt
+++ b/tests/deepclone_hydrate_typed_props.phpt
@@ -1,0 +1,58 @@
+--TEST--
+deepclone_hydrate() verifies declared property types (matching polyfill/setRawValue semantics)
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+class TypedInt
+{
+    public int $x = 0;
+}
+
+class TypedReadonly
+{
+    public readonly int $v;
+}
+
+// A. Strict type mismatch → TypeError
+try {
+    deepclone_hydrate(TypedInt::class, [TypedInt::class => ['x' => 'hello']]);
+    echo "A: NO THROW\n";
+} catch (\TypeError $e) {
+    var_dump(str_contains($e->getMessage(), 'type int'));
+}
+
+// B. Coercible scalar → coerced to int (non-strict default)
+$o = deepclone_hydrate(TypedInt::class, [TypedInt::class => ['x' => '42']]);
+var_dump($o->x === 42);
+
+// C. Readonly + wrong type → TypeError
+try {
+    deepclone_hydrate(TypedReadonly::class, [TypedReadonly::class => ['v' => 'nope']]);
+    echo "C: NO THROW\n";
+} catch (\TypeError $e) {
+    var_dump(str_contains($e->getMessage(), 'type int'));
+}
+
+// D. Same via from_array payload
+try {
+    deepclone_from_array([
+        'classes' => TypedInt::class,
+        'objectMeta' => 1,
+        'prepared' => 0,
+        'properties' => [TypedInt::class => ['x' => [0 => 'hello']]],
+    ]);
+    echo "D: NO THROW\n";
+} catch (\TypeError $e) {
+    var_dump(str_contains($e->getMessage(), 'type int'));
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_private_shadowing.phpt
+++ b/tests/deepclone_private_shadowing.phpt
@@ -1,0 +1,63 @@
+--TEST--
+deepclone_hydrate / from_array handle same-named private in parent and child as distinct slots
+--EXTENSIONS--
+deepclone
+--FILE--
+<?php
+
+class PrivShadowA
+{
+    private string $x = 'a_init';
+    public function get(): string { return $this->x; }
+}
+
+class PrivShadowB extends PrivShadowA
+{
+    private string $x = 'b_init';
+    public function getChild(): string { return $this->x; }
+}
+
+// 1) Per-scope hydrate writes to distinct slots.
+$b = new PrivShadowB();
+deepclone_hydrate($b, [
+    PrivShadowA::class => ['x' => 'A_written'],
+    PrivShadowB::class => ['x' => 'B_written'],
+]);
+var_dump($b->get() === 'A_written');
+var_dump($b->getChild() === 'B_written');
+
+// 2) Roundtrip through to_array/from_array preserves both slots independently.
+$orig = new PrivShadowB();
+$ref = new \ReflectionProperty(PrivShadowA::class, 'x');
+$ref->setValue($orig, 'parent_val');
+$ref2 = new \ReflectionProperty(PrivShadowB::class, 'x');
+$ref2->setValue($orig, 'child_val');
+
+$clone = deepclone_from_array(deepclone_to_array($orig));
+var_dump($clone->get() === 'parent_val');
+var_dump($clone->getChild() === 'child_val');
+
+// 3) Bare name in $mangled_vars targets the most-derived private slot.
+$b2 = new PrivShadowB();
+deepclone_hydrate($b2, [], ['x' => 'bare_val']);
+var_dump($b2->get() === 'a_init');         // parent untouched
+var_dump($b2->getChild() === 'bare_val');  // child written
+
+// 4) Explicit mangled key targets the parent's private slot.
+$b3 = new PrivShadowB();
+deepclone_hydrate($b3, [], ["\0PrivShadowA\0x" => 'parent_targeted']);
+var_dump($b3->get() === 'parent_targeted');
+var_dump($b3->getChild() === 'b_init');
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Done

--- a/tests/deepclone_private_shadowing.phpt
+++ b/tests/deepclone_private_shadowing.phpt
@@ -39,13 +39,13 @@ var_dump($clone->getChild() === 'child_val');
 
 // 3) Bare name in $mangled_vars targets the most-derived private slot.
 $b2 = new PrivShadowB();
-deepclone_hydrate($b2, [], ['x' => 'bare_val']);
+deepclone_hydrate($b2, ['x' => 'bare_val'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($b2->get() === 'a_init');         // parent untouched
 var_dump($b2->getChild() === 'bare_val');  // child written
 
 // 4) Explicit mangled key targets the parent's private slot.
 $b3 = new PrivShadowB();
-deepclone_hydrate($b3, [], ["\0PrivShadowA\0x" => 'parent_targeted']);
+deepclone_hydrate($b3, ["\0PrivShadowA\0x" => 'parent_targeted'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($b3->get() === 'parent_targeted');
 var_dump($b3->getChild() === 'b_init');
 


### PR DESCRIPTION
## Summary

Closes the review chain from @arnaudlb's notes and lands the v0.3.0 feature set
on `deepclone_hydrate()`.

### Review fixups

- `RETURN_THROWS()` after every `zend_throw_*` in PHP_FUNCTIONs.
- `Z_PARAM_OBJ_OR_STR` for the polymorphic first argument.
- `memchr` check moved before the throwaway `zend_string_init` on mangled keys.
- Throw `ValueError` instead of silently `continue`-ing on non-array `scope_bucket`.
- Pack `(ce | ok)` into the per-thread `hydrate_cache` so a class redefinition
  across requests (e.g. shared extension reload) invalidates the entry.
- dtor-reentrance safe `dc_write_property_slot`: copy-out the old value, install
  the new one, then run the destructor — so a `__destruct` reading the same
  slot observes the new value, not a half-freed zval.
- `ZEND_ACC_UNINSTANTIABLE` macro instead of the five-flag spell-out.

### Engine-routed writes

Replace the bespoke direct-slot-write path with engine-blessed dispatch:
- Non-typed, non-hooked → direct slot write (fast path, dtor-safe).
- Typed non-hooked → `zend_update_property_ex` (engine type-checks + coerces
  per call-site `strict_types`).
- Hooked non-virtual → `zend_get_property_hook_trampoline` → bypasses the set
  hook while still type-checking the backing slot. Matches
  `ReflectionProperty::setRawValue` semantics post-GH-17713.

This removes the ext/polyfill divergence on typed-property writes (ext used to
silently store wrong-type values in typed slots; now it type-checks and coerces
like the polyfill / setRawValue).

### Signature collapse + `$flags` parameter

```php
function deepclone_hydrate(object|string $object_or_class, array $vars = [], int $flags = 0): object;
```

`$vars` is the scoped per-class shape by default. Pass
`DEEPCLONE_HYDRATE_MANGLED_VARS` to interpret it as a flat mangled-key array
(`(array) $obj` shape). A NUL-prefixed top-level key in scoped mode raises a
`ValueError` pointing at the missing flag (footgun guard).

Other flags:
- `DEEPCLONE_HYDRATE_CALL_HOOKS` — `ReflectionProperty::setValue` semantics
  (invoke set hooks instead of bypassing them).
- `DEEPCLONE_HYDRATE_NO_LAZY_INIT` — `setRawValueWithoutLazyInitialization`
  semantics: skip the lazy initializer; realize the object when the last lazy
  prop is set. Delegated through `ReflectionProperty` since the engine helpers
  it relies on (`zend_lazy_object_decr_lazy_props`, `zend_lazy_object_realize`)
  aren't `ZEND_API`-exported. Cost localized via:
  - Fast path skipping the Reflection round-trip when the target isn't a lazy
    ghost/proxy with uninitialized props.
  - Per-request `ReflectionProperty` cache keyed by `zend_property_info *`,
    cleared in `PHP_RSHUTDOWN`.

`CALL_HOOKS` and `NO_LAZY_INIT` are mutually exclusive; `MANGLED_VARS` composes
with either. `deepclone_from_array()` keeps the default setRawValue semantics
(payload-driven, mirroring `unserialize()`).

### Forgiving-hydrate behaviors

Decisions rest on the property type only — hook presence and `CALL_HOOKS` don't
change them. Set hooks on enum-typed properties accordingly receive the cast
enum case, not the raw scalar.

- **A1 — readonly idempotent skip**: when the readonly slot already holds an
  identical value (`===`), silently skip. Avoids "Cannot modify readonly
  property" on no-op rehydration.
- **A2 — null → unset for non-nullable typed**: when the payload writes `null`
  into a non-nullable typed prop, store `IS_UNDEF | IS_PROP_UNINIT` instead of
  raising `TypeError` — restores the uninitialized-typed state otherwise
  unreachable via hydration. Hooked properties are excluded outright (no
  backing slot to "unset" semantically; a set hook may handle `null` itself).
- **A3 — scalar → backed-enum cast**: when the prop is typed with a single
  (possibly nullable) backed enum, scalar payload values are cast via
  `Enum::from()`. Unknown values raise the standard `ValueError` from
  `Enum::from()`; unions/intersections leave the value untouched.