### PR TITLE
Update phpt message assertion for v0.3.0 BC break

### DIFF
--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -285,7 +285,7 @@ try {
 try {
     deepclone_hydrate('stdClass', ['stdClass' => ["\0stdClass\0x" => 'val']]);
 } catch (\ValueError $e) {
-    var_dump(str_contains($e->getMessage(), 'mangled key'));
+    var_dump(str_contains($e->getMessage(), 'DEEPCLONE_HYDRATE_MANGLED_VARS'));
 }
 
 // Interface as scope → ValueError


### PR DESCRIPTION
## Summary

`tests/deepclone_hydrate.phpt` asserted on the substring `'mangled key'` in the `ValueError` raised when a mangled key appears inside a scoped array. The v0.3.0 BC-break rename (`$scoped_vars`+`$mangled_vars` → single `$vars` + `DEEPCLONE_HYDRATE_MANGLED_VARS` flag) updated the message to point users at the new flag/arg; the old substring no longer matches.

Post-tag CI catch — all platforms (Linux NTS/ZTS/i386/debug, macOS, Windows) flagged the same assertion. Switched the check to `'DEEPCLONE_HYDRATE_MANGLED_VARS'` so it tracks the current message.

## Test plan

- [x] CI is green across the matrix