### PR TITLE
Add DEEPCLONE_HYDRATE_PRESERVE_REFS flag (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-15
+
+### BC Break
+
+- `deepclone_hydrate()` no longer preserves PHP `&` references from `$vars`
+  onto the target property slots by default. Incoming reference zvals are
+  dereferenced on write (`ZVAL_DEREF`), so property slots hold plain values
+  instead of ref links. Pass the new `DEEPCLONE_HYDRATE_PRESERVE_REFS` flag
+  in `$flags` to opt back into the old behavior. Motivation: the ref-preserving
+  path requires a per-call probe of the input array, which dominated cost for
+  typical DTO hydration; making it opt-in brings the polyfill in line with
+  Reflection-based hydrators on ref-less input. Callers that intentionally
+  share a value slot between two properties (or between a property and a
+  caller-side variable) need to add the flag.
+
+### Added
+
+- `DEEPCLONE_HYDRATE_PRESERVE_REFS` constant — see BC break above. Composes
+  with `DEEPCLONE_HYDRATE_MANGLED_VARS`, `DEEPCLONE_HYDRATE_CALL_HOOKS`, and
+  `DEEPCLONE_HYDRATE_NO_LAZY_INIT`.
+
 ## [0.3.1] - 2026-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `DEEPCLONE_HYDRATE_MANGLED_VARS`, `DEEPCLONE_HYDRATE_CALL_HOOKS`, and
   `DEEPCLONE_HYDRATE_NO_LAZY_INIT`.
 
+### Changed
+
+- `deepclone_hydrate()` scoped-mode property-name validation now matches
+  `unserialize()` permissiveness: integer keys coerce to strings on dynamic
+  property access; NUL-in-middle names are stored as raw dynamic properties
+  (same as `unserialize()` on an `O:…` payload with a NUL-containing key);
+  NUL-prefix names surface the engine's native `Error: Cannot access property
+  starting with "\0"`. The pre-v0.4.0 `ValueError` was stricter than
+  `unserialize()` and cost a per-prop validation in the hot path; dropping it
+  aligns the semantics and saves hot-path work. `DEEPCLONE_HYDRATE_MANGLED_VARS`
+  mode still parses and validates mangled keys.
+
 ## [0.3.1] - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,10 +120,19 @@ $user = deepclone_hydrate(User::class,
 | `DEEPCLONE_HYDRATE_CALL_HOOKS`         | `ReflectionProperty::setValue` — invoke set hooks |
 | `DEEPCLONE_HYDRATE_NO_LAZY_INIT`       | `ReflectionProperty::setRawValueWithoutLazyInitialization` — skip the lazy initializer; realize the object when the last lazy property is set |
 | `DEEPCLONE_HYDRATE_MANGLED_VARS`       | interpret `$vars` as a flat mangled-key array (above) |
+| `DEEPCLONE_HYDRATE_PRESERVE_REFS`      | preserve PHP `&` references from `$vars` onto the target property slots; by default, references are dropped (dereferenced) on write |
 
 `DEEPCLONE_HYDRATE_CALL_HOOKS` and `DEEPCLONE_HYDRATE_NO_LAZY_INIT` are
-mutually exclusive; `MANGLED_VARS` composes with either. `deepclone_from_array()`
-always uses the default setRawValue semantics, mirroring `unserialize()`.
+mutually exclusive; `MANGLED_VARS` and `PRESERVE_REFS` compose with either.
+`deepclone_from_array()` always uses the default setRawValue semantics,
+mirroring `unserialize()`.
+
+`PRESERVE_REFS` is off by default because preserving references requires a
+per-call probe of the input array, which costs more than the typical DTO
+hydration saves by using the ext over Reflection. Pass the flag when you
+actually need a property slot to remain aliased to a caller-side variable or
+to another property (e.g. when rehydrating a graph previously exported with
+`deepclone_to_array()` that contained `&` references).
 
 ### Forgiving payload handling
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -153,8 +153,9 @@ static zend_always_inline zend_class_entry *dc_register_internal_class_with_flag
 #define DEEPCLONE_HYDRATE_CALL_HOOKS    (1 << 0)
 #define DEEPCLONE_HYDRATE_NO_LAZY_INIT  (1 << 1)
 #define DEEPCLONE_HYDRATE_MANGLED_VARS  (1 << 2)
+#define DEEPCLONE_HYDRATE_PRESERVE_REFS (1 << 3)
 #define DEEPCLONE_HYDRATE_FLAGS_MASK \
-	(DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT | DEEPCLONE_HYDRATE_MANGLED_VARS)
+	(DEEPCLONE_HYDRATE_CALL_HOOKS | DEEPCLONE_HYDRATE_NO_LAZY_INIT | DEEPCLONE_HYDRATE_MANGLED_VARS | DEEPCLONE_HYDRATE_PRESERVE_REFS)
 
 /* The stub-generated header relies on the compat shims above (specifically
  * zend_register_internal_class_with_flags on PHP < 8.4), so it has to be
@@ -3280,6 +3281,14 @@ add_to_scope:
 					}
 				}
 				continue;
+			}
+
+			/* Default: the input's PHP & references are dropped (dereferenced) on
+			 * write. Pass DEEPCLONE_HYDRATE_PRESERVE_REFS to keep the ref link,
+			 * which matters for call sites that intentionally share a value slot
+			 * between two properties or between a property and a caller-side var. */
+			if (!(flags & DEEPCLONE_HYDRATE_PRESERVE_REFS)) {
+				ZVAL_DEREF(prop_val);
 			}
 
 			if (obj_ce == zend_standard_class_def) {

--- a/deepclone.c
+++ b/deepclone.c
@@ -3218,16 +3218,16 @@ add_to_scope:
 			EG(fake_scope) = scope_ce;
 		}
 
+		zend_ulong prop_idx;
 		zend_string *prop_name;
 		zval *prop_val;
-		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(scope_props), prop_name, prop_val) {
-			if (UNEXPECTED(!prop_name)) {
-				zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" must have only string keys",
-					ZSTR_VAL(scope_name));
-				EG(fake_scope) = old_scope;
-				if (scoped_owned) zval_ptr_dtor(&local_scoped);
-				zval_ptr_dtor(&obj_zval);
-				RETURN_THROWS();
+		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(scope_props), prop_idx, prop_name, prop_val) {
+			/* Integer keys: coerce to string on dynamic property access, matching
+			 * unserialize()'s permissiveness. Allocated name is released below. */
+			bool prop_name_owned = false;
+			if (!prop_name) {
+				prop_name = zend_long_to_str((zend_long) prop_idx);
+				prop_name_owned = true;
 			}
 
 			/* "\0" key = internal state for ArrayObject/ArrayIterator/SplObjectStorage */
@@ -3292,15 +3292,9 @@ add_to_scope:
 			}
 
 			if (obj_ce == zend_standard_class_def) {
-				if (UNEXPECTED(memchr(ZSTR_VAL(prop_name), '\0', ZSTR_LEN(prop_name)) != NULL)) {
-					zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" contains an invalid property name; "
-						"use bare property names in scoped mode, or pass DEEPCLONE_HYDRATE_MANGLED_VARS in $flags",
-						ZSTR_VAL(scope_name));
-					EG(fake_scope) = old_scope;
-					if (scoped_owned) zval_ptr_dtor(&local_scoped);
-					zval_ptr_dtor(&obj_zval);
-					RETURN_THROWS();
-				}
+				/* Matches unserialize(): NUL-in-middle names are stored as-is,
+				 * NUL-prefix names are rejected by the engine on read. No
+				 * pre-validation — the polyfill follows the same rule. */
 				Z_TRY_ADDREF_P(prop_val);
 				zend_hash_update(obj->properties, prop_name, prop_val);
 			} else {
@@ -3317,24 +3311,19 @@ add_to_scope:
 				if (dc_is_backed_declared_property(pi)) {
 					bool ok = dc_write_backed_property(obj, pi, prop_name, prop_val, flags);
 					if (UNEXPECTED(!ok)) {
+						if (prop_name_owned) zend_string_release(prop_name);
 						EG(fake_scope) = old_scope;
 						if (scoped_owned) zval_ptr_dtor(&local_scoped);
 						zval_ptr_dtor(&obj_zval);
 						RETURN_THROWS();
 					}
 				} else {
-					/* Fallback: dynamic property or unknown name — validate first */
-					if (UNEXPECTED(memchr(ZSTR_VAL(prop_name), '\0', ZSTR_LEN(prop_name)) != NULL)) {
-						zend_value_error("deepclone_hydrate(): Argument #2 ($vars) scope \"%s\" contains an invalid property name; "
-							"use bare property names in scoped mode, or pass DEEPCLONE_HYDRATE_MANGLED_VARS in $flags",
-							ZSTR_VAL(scope_name));
-						EG(fake_scope) = old_scope;
-						if (scoped_owned) zval_ptr_dtor(&local_scoped);
-						zval_ptr_dtor(&obj_zval);
-						return;
-					}
+					/* Fallback: dynamic property or unknown name. Matches
+					 * unserialize(): the engine rejects NUL-prefix names with
+					 * \Error and accepts NUL-in-middle as raw dynamic props. */
 					zend_std_write_property(obj, prop_name, prop_val, NULL);
 					if (UNEXPECTED(EG(exception))) {
+						if (prop_name_owned) zend_string_release(prop_name);
 						EG(fake_scope) = old_scope;
 						if (scoped_owned) zval_ptr_dtor(&local_scoped);
 						zval_ptr_dtor(&obj_zval);
@@ -3342,6 +3331,7 @@ add_to_scope:
 					}
 				}
 			}
+			if (prop_name_owned) zend_string_release(prop_name);
 		} ZEND_HASH_FOREACH_END();
 
 		EG(fake_scope) = old_scope;

--- a/deepclone.stub.php
+++ b/deepclone.stub.php
@@ -29,6 +29,12 @@ namespace {
      */
     const DEEPCLONE_HYDRATE_MANGLED_VARS = UNKNOWN;
 
+    /**
+     * @var int
+     * @cvalue DEEPCLONE_HYDRATE_PRESERVE_REFS
+     */
+    const DEEPCLONE_HYDRATE_PRESERVE_REFS = UNKNOWN;
+
     function deepclone_to_array(mixed $value, ?array $allowed_classes = null): array {}
 
     function deepclone_from_array(array $data, ?array $allowed_classes = null): mixed {}

--- a/deepclone_arginfo.h
+++ b/deepclone_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit deepclone.stub.php instead.
- * Stub hash: 2383b81a7c575515337480af636d47f80d3c77f0 */
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 9880c7855ef1f15a09a60285c303666d90ce82f2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_deepclone_to_array, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -33,6 +33,7 @@ static void register_deepclone_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_CALL_HOOKS", DEEPCLONE_HYDRATE_CALL_HOOKS, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_NO_LAZY_INIT", DEEPCLONE_HYDRATE_NO_LAZY_INIT, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_MANGLED_VARS", DEEPCLONE_HYDRATE_MANGLED_VARS, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("DEEPCLONE_HYDRATE_PRESERVE_REFS", DEEPCLONE_HYDRATE_PRESERVE_REFS, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class_DeepClone_NotInstantiableException(zend_class_entry *class_entry_InvalidArgumentException)

--- a/php_deepclone.h
+++ b/php_deepclone.h
@@ -4,7 +4,7 @@
 extern zend_module_entry deepclone_module_entry;
 #define phpext_deepclone_ptr &deepclone_module_entry
 
-#define PHP_DEEPCLONE_VERSION "0.3.1"
+#define PHP_DEEPCLONE_VERSION "0.4.0"
 
 ZEND_BEGIN_MODULE_GLOBALS(deepclone)
 	HashTable hydrate_cache;

--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -268,32 +268,30 @@ try {
     var_dump(str_contains($e->getMessage(), 'array values'));
 }
 
-// NUL byte in property name inside scoped array → ValueError
-try {
-    deepclone_hydrate('stdClass', ['stdClass' => ["foo\0bar" => 'val']]);
-} catch (\ValueError $e) {
-    var_dump(str_contains($e->getMessage(), 'invalid property name'));
-}
+// NUL-in-middle of a property name: matches unserialize() — accepted
+// as a dynamic property, the engine stores the raw name.
+$o = deepclone_hydrate('stdClass', ['stdClass' => ["foo\0bar" => 'val']]);
+var_dump(((array) $o)["foo\0bar"] === 'val');
 
-// NUL byte in mangled key property portion → ValueError
+// NUL byte in mangled key property portion → ValueError (MANGLED_VARS mode parses keys)
 try {
     deepclone_hydrate('stdClass', ["\0*\0foo\0bar" => 'val'], DEEPCLONE_HYDRATE_MANGLED_VARS);
 } catch (\ValueError $e) {
     var_dump(str_contains($e->getMessage(), 'invalid mangled key'));
 }
 
-// Integer key inside scoped array → ValueError
-try {
-    deepclone_hydrate('stdClass', ['stdClass' => [0 => 'val']]);
-} catch (\ValueError $e) {
-    var_dump(str_contains($e->getMessage(), 'string keys'));
-}
+// Integer key inside a scope: matches unserialize() — coerced to string
+// on dynamic property access.
+$o = deepclone_hydrate('stdClass', ['stdClass' => [0 => 'val']]);
+var_dump($o->{'0'} === 'val');
 
-// Mangled key inside scoped array → ValueError
+// Mangled-shape key inside a scope: engine rejects the NUL-prefix
+// property name with \Error. Callers wanting mangled keys pass
+// DEEPCLONE_HYDRATE_MANGLED_VARS.
 try {
     deepclone_hydrate('stdClass', ['stdClass' => ["\0stdClass\0x" => 'val']]);
-} catch (\ValueError $e) {
-    var_dump(str_contains($e->getMessage(), 'DEEPCLONE_HYDRATE_MANGLED_VARS'));
+} catch (\Error $e) {
+    var_dump(str_contains($e->getMessage(), 'starting with'));
 }
 
 // Interface as scope → ValueError
@@ -326,7 +324,6 @@ var_dump($o instanceof stdClass);
 echo "Done\n";
 ?>
 --EXPECT--
-bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -155,17 +155,25 @@ var_dump($obj->getValue() === 123);
 $obj = deepclone_hydrate('ReadonlyClass', ['ReadonlyClass' => ['value' => 456]]);
 var_dump($obj->getValue() === 456);
 
-// PHP references preservation (mangled mode keeps refs across the hydrate)
+// PHP references are dropped by default (deref on write)
 $a = 1;
 $props = ['p1' => &$a, 'p2' => &$a];
 $obj = deepclone_hydrate('stdClass', $props, DEEPCLONE_HYDRATE_MANGLED_VARS);
 var_dump($obj->p1 === 1 && $obj->p2 === 1);
 $a = 2;
+var_dump($obj->p1 === 1 && $obj->p2 === 1); // stayed at 1 — no ref preserved
+
+// PRESERVE_REFS keeps the ref link across the hydrate
+$a = 1;
+$props = ['p1' => &$a, 'p2' => &$a];
+$obj = deepclone_hydrate('stdClass', $props, DEEPCLONE_HYDRATE_MANGLED_VARS | DEEPCLONE_HYDRATE_PRESERVE_REFS);
+var_dump($obj->p1 === 1 && $obj->p2 === 1);
+$a = 2;
 var_dump($obj->p1 === 2 && $obj->p2 === 2);
 
-// References in scoped properties
+// Refs in scoped properties also need PRESERVE_REFS
 $v = 'hello';
-$obj = deepclone_hydrate('stdClass', ['stdClass' => ['x' => &$v, 'y' => &$v]]);
+$obj = deepclone_hydrate('stdClass', ['stdClass' => ['x' => &$v, 'y' => &$v]], DEEPCLONE_HYDRATE_PRESERVE_REFS);
 $v = 'world';
 var_dump($obj->x === 'world' && $obj->y === 'world');
 
@@ -318,6 +326,8 @@ var_dump($o instanceof stdClass);
 echo "Done\n";
 ?>
 --EXPECT--
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
## Summary

Two related changes for v0.4.0 on `deepclone_hydrate()`:

1. **Make ref-preservation opt-in** via a new `DEEPCLONE_HYDRATE_PRESERVE_REFS` flag — by default, PHP `&` references in `$vars` are dropped on write.
2. **Align scoped-mode property-name validation with `unserialize()`** — drop the pre-v0.4.0 `ValueError` on integer keys / NUL-in-middle / mangled-shape keys in favor of the engine's native semantics.

Motivation comes from the polyfill side: both the unconditional ref-probe and the per-prop name check dominated cost for typical DTO hydration. With both relaxed, the polyfill now matches or beats raw Reflection for flat-class hydration. Keeping ext/polyfill semantics aligned means shipping the same changes on both sides.

## 1. PRESERVE_REFS flag

| Call | Behavior |
|------|----------|
| `deepclone_hydrate($obj, $vars)` | references in `$vars` are dereferenced — property slots hold plain values |
| `deepclone_hydrate($obj, $vars, DEEPCLONE_HYDRATE_PRESERVE_REFS)` | ref links are preserved (pre-0.4.0 default) |

Composes with `MANGLED_VARS`, `CALL_HOOKS`, and `NO_LAZY_INIT`.

### BC break

Callers that intentionally share a value slot between two properties (or between a property and a caller-side variable) must add `DEEPCLONE_HYDRATE_PRESERVE_REFS`. `symfony/var-exporter`'s `Hydrator::hydrate()` and `Instantiator::instantiate()` pass the flag internally to preserve the VarExporter contract.

## 2. unserialize()-permissive property-name handling in scoped mode

In scoped mode, the pre-v0.4.0 hot-path validation rejected integer keys, NUL-in-middle names, and mangled-shape keys with a `ValueError`. That was stricter than what `unserialize()` does on the same shapes in an `O:…` payload. The ext now:

- **Integer keys** — coerce to string on dynamic property access (PHP engine rule). Iteration switched to `ZEND_HASH_FOREACH_KEY_VAL` with `zend_long_to_str` for the synthesised name.
- **NUL-in-middle names** — stored as raw dynamic properties, same as `unserialize()`.
- **NUL-prefix names** — surface the engine's native `Error: Cannot access property starting with "\0"` from `zend_std_write_property` / `zend_hash_update`.

`DEEPCLONE_HYDRATE_MANGLED_VARS` mode still parses and validates mangled keys (that's the entire point of the flag).

## Implementation

- [`deepclone.c`](deepclone.c):
  - `ZVAL_DEREF(prop_val)` at the top of the inner write loop when `PRESERVE_REFS` is absent (zero overhead when the zval isn't a ref — one type-tag check per prop).
  - Dropped the `memchr` NUL check on the stdClass and dynamic-fallback write paths.
  - Switched the inner loop from `ZEND_HASH_FOREACH_STR_KEY_VAL` to `ZEND_HASH_FOREACH_KEY_VAL`, synthesising the property name for integer keys.
- [`deepclone.stub.php`](deepclone.stub.php) / regenerated [`deepclone_arginfo.h`](deepclone_arginfo.h): expose `DEEPCLONE_HYDRATE_PRESERVE_REFS = 1 << 3`.
- [`tests/deepclone_hydrate.phpt`](tests/deepclone_hydrate.phpt): ref-preservation tests exercise both the default-drop and `PRESERVE_REFS` paths; property-name tests updated to reflect `unserialize()`-matching behavior.
- [`README.md`](README.md): flag table + rationale paragraph.
- [`CHANGELOG.md`](CHANGELOG.md): `0.4.0` entry (BC break + Added + Changed).
- [`php_deepclone.h`](php_deepclone.h): bump to `0.4.0` (minor SemVer since default semantics change).

## Test plan

- [x] 30/30 `.phpt` tests green locally (PHP 8.4, NTS)
- [x] CI green on the matrix (Linux NTS/ZTS/i386/debug, macOS, Windows)

See the polyfill-side changes (same flags, same semantics) in the companion PR on `symfony/polyfill`.