### PR TITLE
Direct-write fast path for bare-name keys in MANGLED_VARS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,22 @@ properties — including private, protected, and readonly ones — without calli
 their constructor, faster than Reflection:
 
 ```php
-// Set private properties via scoped array (fastest path)
+// Scoped array — keyed by declaring class
 $user = deepclone_hydrate(User::class, [
     User::class => ['id' => 42, 'name' => 'Alice'],
     AbstractEntity::class => ['createdAt' => new \DateTimeImmutable()],
 ]);
 
-// Instantiate from class name with mangled keys (same format as (array) cast)
+// Flat bare-name array — ideal for hydrating from a flat row
+// (e.g. a PDO result), no scope grouping needed
 $user = deepclone_hydrate(User::class,
-    ['name' => 'Alice', 'email' => 'alice@example.com'],
+    ['id' => 42, 'name' => 'Alice', 'email' => 'alice@example.com'],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
+
+// Mangled keys (same format as (array) $obj cast)
+$user = deepclone_hydrate(User::class,
+    ['name' => 'Alice', "\0User\0email" => 'alice@example.com'],
     DEEPCLONE_HYDRATE_MANGLED_VARS,
 );
 
@@ -86,12 +93,12 @@ function deepclone_hydrate(object|string $object_or_class, array $vars = [], int
 the list.
 
 `deepclone_hydrate()` accepts either an object to hydrate in place or a class
-name to instantiate without calling its constructor. PHP `&` references in
-`$vars` are preserved through the hydrate.
+name to instantiate without calling its constructor. By default, PHP `&`
+references in `$vars` are dropped on write; pass `DEEPCLONE_HYDRATE_PRESERVE_REFS`
+to keep them.
 
 By default, `$vars` is keyed by declaring class name; each value is an array
-of property names to values. This is the fastest path — direct slot writes,
-no key parsing.
+of property names to values:
 
 ```php
 $user = deepclone_hydrate(User::class, [
@@ -101,16 +108,29 @@ $user = deepclone_hydrate(User::class, [
 ```
 
 Pass `DEEPCLONE_HYDRATE_MANGLED_VARS` in `$flags` to interpret `$vars` as a
-flat mangled-key array (the same shape `(array) $object` produces):
-`"\0ClassName\0prop"` for private, `"\0*\0prop"` for protected, bare name
-for public/dynamic. Each key is resolved to its scope automatically.
+flat key array. Keys can be bare property names (auto-resolved to the
+declaring class, the ideal shape for hydrating from a PDO row), or
+mangled (`"\0ClassName\0prop"` for private, `"\0*\0prop"` for protected — the
+same shape `(array) $object` produces). The two forms can be mixed:
 
 ```php
+// Bare names — each is resolved to its declaring class automatically
+$user = deepclone_hydrate(User::class,
+    ['id' => 42, 'name' => 'Alice', 'email' => 'alice@example.com'],
+    DEEPCLONE_HYDRATE_MANGLED_VARS,
+);
+
+// Mangled keys, typical (array) cast shape
 $user = deepclone_hydrate(User::class,
     ['name' => 'Alice', "\0User\0email" => 'alice@example.com'],
     DEEPCLONE_HYDRATE_MANGLED_VARS,
 );
 ```
+
+Both the scoped shape and the flat-bare-name shape take a direct
+`properties_info` lookup per key followed by a direct slot write — there's
+no meaningful performance difference between the two, pick whichever
+representation your caller already has on hand.
 
 `$flags` selects the write semantics for declared-property assignments:
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -3101,6 +3101,25 @@ PHP_FUNCTION(deepclone_hydrate)
 				/* Bare name — find declaring class */
 				real_name = prop_key;
 				zend_property_info *pi = zend_hash_find_ptr(&obj_ce->properties_info, real_name);
+
+				/* Fast path: the resolved property has a real backing slot (typed or
+				 * non-hooked). Write directly via dc_write_backed_property and skip the
+				 * scoped_props accumulation + second-pass write. This is the hot case
+				 * for Doctrine-style `fetchAll()` flows where the row is a flat dict
+				 * of declared field names. */
+				if (pi && !(pi->flags & ZEND_ACC_STATIC) && dc_is_backed_declared_property(pi)) {
+					zval *v = prop_val;
+					if (!(flags & DEEPCLONE_HYDRATE_PRESERVE_REFS)) {
+						ZVAL_DEREF(v);
+					}
+					if (UNEXPECTED(!dc_write_backed_property(Z_OBJ(obj_zval), pi, real_name, v, flags))) {
+						if (scoped_owned) zval_ptr_dtor(&local_scoped);
+						zval_ptr_dtor(&obj_zval);
+						RETURN_THROWS();
+					}
+					continue;
+				}
+
 				if (pi && !(pi->flags & ZEND_ACC_STATIC)) {
 					scope_str = pi->ce->name;
 					/* For private-set properties, use the declaring class as write scope */


### PR DESCRIPTION
## Summary

When callers pass a flat `$vars` dictionary of bare property names (no `"\0ClassName\0prop"` mangling), the MANGLED_VARS parser previously resolved each key to `(scope, name)` and stashed it in an intermediate `scoped_props` HashTable, then ran the regular scoped-mode write in a **second pass**. For the typical ORM flow (`fetchAll()` → flat row dict of declared field names), that double iteration was pure overhead.

The parser now resolves `property_info` for each bare key and — when it points at a real backed declared property — calls `dc_write_backed_property()` immediately, skipping `scoped_props` accumulation and the second-pass iteration.

NUL-prefix (mangled) keys, unresolved names, and hooked/virtual properties fall through to the original path, so error handling, scope tracking, and per-scope `EG(fake_scope)` semantics are unchanged.

## Benchmark

Customer entity, 11 fields, 3-level inheritance (`Customer → Person → Entity`), 100-entity batch on PHP 8.4:

| shape                                                        | before | after |
|--------------------------------------------------------------|-------:|------:|
| `deepclone_hydrate($class, $flatRow, MANGLED_VARS)`          | 1,275  |   486 |
| Doctrine's `setValue` loop (reference, unchanged)            | 1,131  | 1,131 |
| `deepclone_hydrate` scoped (pre-built scoped shape, ideal)   |   428  |   428 |

**2.33× speedup over Doctrine's current approach**, within ~58 ns of the hand-built scoped-shape path.

## Why this matters for Doctrine / ORM users

The natural way a Doctrine-style `ObjectHydrator` has its data is a flat `[field => value]` dict from PDO. Before this commit, to take advantage of the ext they had to either:

1. Build a nested `[scope => [field => value]]` shape per row (scope-grouping tax eats the speedup), or
2. Pre-compute mangled keys `"\0Class\0field"` in `ClassMetadata` and remap each row through them (more hashing, same intermediate-hashtable penalty).

With this fast path, they can pass `$row` as-is with `DEEPCLONE_HYDRATE_MANGLED_VARS` and get full ext-speed hydration.

## Test plan

- [x] 30/30 `.phpt` tests green locally (PHP 8.4, NTS)
- [ ] CI green across the matrix