### PR TITLE
Review fixups from @arnaudlb against v0.4.0

### DIFF
--- a/deepclone.c
+++ b/deepclone.c
@@ -638,15 +638,11 @@ static zend_always_inline bool dc_class_allowed(HashTable *set, zend_string *nam
 
 static zend_always_inline bool dc_is_backed_declared_property(zend_property_info *pi)
 {
-	/* A "backed declared property" is a non-static, non-virtual property with
-	 * a real backing slot (offset >= ZEND_FIRST_PROPERTY_OFFSET). Hooked
-	 * non-virtual properties qualify (they have a real offset); virtual
-	 * properties and hook-metadata offsets do not. */
-	return pi
-		&& !(pi->flags & ZEND_ACC_STATIC)
-		&& !(pi->flags & ZEND_ACC_VIRTUAL)
-		&& pi->offset != ZEND_VIRTUAL_PROPERTY_OFFSET
-		&& !IS_HOOKED_PROPERTY_OFFSET(pi->offset);
+	/* Non-static, non-virtual property with a real backing slot. ZEND_ACC_VIRTUAL
+	 * already implies pi->offset == ZEND_VIRTUAL_PROPERTY_OFFSET, and
+	 * IS_HOOKED_PROPERTY_OFFSET() is only meaningful on offsets returned by
+	 * zend_get_property_offset() — not on the raw pi->offset. */
+	return pi && !(pi->flags & (ZEND_ACC_STATIC | ZEND_ACC_VIRTUAL));
 }
 
 static zend_always_inline bool dc_is_std_scope_property(zend_property_info *pi)

--- a/deepclone.c
+++ b/deepclone.c
@@ -732,6 +732,15 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 #if PHP_VERSION_ID >= 80400
 	bool call_hooks   = (flags & DEEPCLONE_HYDRATE_CALL_HOOKS) != 0;
 	bool no_lazy_init = (flags & DEEPCLONE_HYDRATE_NO_LAZY_INIT) != 0;
+
+	/* Lazy objects: a direct slot write would bypass the engine's realization
+	 * hook and leave the object in a half-initialized state. Route through
+	 * zend_update_property_ex() which triggers realization on first write.
+	 * DEEPCLONE_HYDRATE_NO_LAZY_INIT has its own opt-out fast path below. */
+	if (!no_lazy_init && UNEXPECTED(!zend_lazy_object_initialized(obj))) {
+		zend_update_property_ex(pi->ce, obj, name, value);
+		return !EG(exception);
+	}
 #endif
 	zval *slot = OBJ_PROP(obj, pi->offset);
 

--- a/deepclone.c
+++ b/deepclone.c
@@ -769,7 +769,11 @@ static bool dc_write_backed_property(zend_object *obj, zend_property_info *pi,
 	bool enum_holder_used = false;
 	if ((Z_TYPE_P(value) == IS_LONG || Z_TYPE_P(value) == IS_STRING)
 		&& ZEND_TYPE_HAS_NAME(pi->type)
-		&& !ZEND_TYPE_HAS_LIST(pi->type))
+		&& !ZEND_TYPE_HAS_LIST(pi->type)
+		/* Only cast for types of the form `Enum` or `?Enum` — unions like
+		 * `Enum|string|int` already accept the scalar literally, so casting
+		 * it to an enum case would be surprising. */
+		&& (ZEND_TYPE_PURE_MASK(pi->type) & ~MAY_BE_NULL) == 0)
 	{
 		zend_class_entry *type_ce = zend_lookup_class_ex(
 			ZEND_TYPE_NAME(pi->type), NULL, ZEND_FETCH_CLASS_NO_AUTOLOAD);

--- a/deepclone.c
+++ b/deepclone.c
@@ -3346,10 +3346,13 @@ add_to_scope:
 						RETURN_THROWS();
 					}
 				} else {
-					/* Fallback: dynamic property or unknown name. Matches
-					 * unserialize(): the engine rejects NUL-prefix names with
-					 * \Error and accepts NUL-in-middle as raw dynamic props. */
-					zend_std_write_property(obj, prop_name, prop_val, NULL);
+					/* Fallback: dynamic property or unknown name. Goes through
+					 * zend_update_property_ex() so any overridden write_property
+					 * handler (internal classes, extensions overriding default
+					 * handlers) is respected. Matches unserialize(): the engine
+					 * rejects NUL-prefix names with \Error and accepts NUL-in-middle
+					 * as raw dynamic properties. */
+					zend_update_property_ex(scope_ce ?: obj_ce, obj, prop_name, prop_val);
 					if (UNEXPECTED(EG(exception))) {
 						if (prop_name_owned) zend_string_release(prop_name);
 						EG(fake_scope) = old_scope;


### PR DESCRIPTION
Addresses review feedback from @arnaudlb on the v0.4.0 work (PR #12), split into four semantic commits so each concern can be reviewed (and reverted) independently.

## Commits

### 1. [Simplify `dc_is_backed_declared_property()`](../commit/25226d3)

`!(pi->flags & ZEND_ACC_VIRTUAL)` already implies `pi->offset == ZEND_VIRTUAL_PROPERTY_OFFSET` (both set together for virtual props on the property_info side), and `IS_HOOKED_PROPERTY_OFFSET()` is only meaningful on offsets returned by `zend_get_property_offset()` — not on the raw `pi->offset`. Collapse to a single bitmask test.

### 2. [Narrow backed-enum scalar cast to `Enum` / `?Enum` only](../commit/8278442)

The scalar→backed-enum coercion shouldn't fire for union types that already accept the scalar literally (e.g. `Suit|string|int`). Add `(ZEND_TYPE_PURE_MASK(pi->type) & ~MAY_BE_NULL) == 0` so only pure-enum types (nullable or not) trigger the cast.

### 3. [Route writes on lazy objects through `zend_update_property_ex()`](../commit/9acaa92)

A lazy ghost keeps its backing slots uninitialized until the realization hook fires. Writing directly via `OBJ_PROP` would bypass that hook and leave the object in a half-initialized state. At the top of `dc_write_backed_property()`, check `zend_lazy_object_initialized()` and delegate to the engine's property write path in the default mode. `DEEPCLONE_HYDRATE_NO_LAZY_INIT` keeps its opt-out fast path.

### 4. [Route dynamic-property fallback through `zend_update_property_ex()`](../commit/HEAD)

`zend_std_write_property()` skips any overridden `write_property` handler. For internal classes or user objects that swap handlers at `create_object` time, that bypasses semantic validation the class expects. Switch to `zend_update_property_ex(scope_ce ?: obj_ce, obj, name, value)`.

## Notes on not-applied comments

- **A2 (null → unset on non-nullable typed) and A3 (scalar → backed-enum cast)**: kept property-type-only as discussed — the coercions are driven by the target type at hydration time, which is stable within a single execution. Adding a hook or changing a property type is a code change, not a runtime surprise. Scenario A3 also gets the type-narrowing from commit 2.

## Test plan

- [x] 30/30 `.phpt` tests green locally (PHP 8.4, NTS)
- [ ] CI green on the matrix