### PR TITLE
deepclone_to_array: resolve INDIRECT slots in retained __serialize() states

### DIFF
--- a/deepclone.c
+++ b/deepclone.c
@@ -964,6 +964,17 @@ static void dc_copy_array(dc_ctx *ctx, HashTable *src_ht, zval *dst, zval *mask_
 	zend_hash_real_init_mixed(Z_ARRVAL_P(mask_dst));
 
 	ZEND_HASH_FOREACH_KEY_VAL(src_ht, idx, key, src_val) {
+		/* __serialize() may return the object's raw property table (e.g.
+		 * Random\Randomizer before PHP 8.3), where declared properties are
+		 * IS_INDIRECT slots into the object. Resolve them like the native
+		 * serializer does, or the payload would retain pointers that dangle
+		 * once the source object is released. */
+		if (UNEXPECTED(Z_TYPE_P(src_val) == IS_INDIRECT)) {
+			src_val = Z_INDIRECT_P(src_val);
+			if (Z_TYPE_P(src_val) == IS_UNDEF) {
+				continue;
+			}
+		}
 		zval undef, null_marker;
 		ZVAL_UNDEF(&undef);
 		ZVAL_NULL(&null_marker);

--- a/tests/deepclone_randomizer.phpt
+++ b/tests/deepclone_randomizer.phpt
@@ -1,0 +1,34 @@
+--TEST--
+deepclone round-trips a Random\Randomizer that does not outlive its payload
+--EXTENSIONS--
+deepclone
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80200) die('skip requires PHP 8.2'); ?>
+--FILE--
+<?php
+
+// Before PHP 8.3, Randomizer::__serialize() returns its raw property table,
+// whose "engine" slot is an IS_INDIRECT pointer into the object. The payload
+// must not retain it once the source Randomizer is released.
+$expected = (new Random\Randomizer(new Random\Engine\Mt19937(42)))->getInt(1, PHP_INT_MAX);
+
+$d = deepclone_to_array(new Random\Randomizer(new Random\Engine\Mt19937(42)));
+gc_collect_cycles();
+$clone = deepclone_from_array($d);
+var_dump($clone instanceof Random\Randomizer);
+var_dump($expected === $clone->getInt(1, PHP_INT_MAX));
+
+// Same with the Randomizer nested in a temporary object graph
+$g = deepclone_from_array(deepclone_to_array((object) ['list' => [(object) ['r' => new Random\Randomizer(new Random\Engine\Mt19937(9))]]]));
+var_dump($g->list[0]->r instanceof Random\Randomizer);
+
+// And behind a shared identity
+$r = new Random\Randomizer(new Random\Engine\Mt19937(5));
+$c = deepclone_from_array(deepclone_to_array([$r, $r]));
+var_dump($c[0] === $c[1]);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Before PHP 8.3, `Random\Randomizer::__serialize()` returns the object's raw property table with only the table itself addref'd; its `engine` entry is an `IS_INDIRECT` slot pointing into the object. php-src fixed it for 8.3 by duplicating the table (php/php-src@c5fa7696e64), but the fix was never backported to the by-then security-only 8.2, which still ships the dangling behavior in its final release.

`deepclone_to_array()` walks such a state with `dc_copy_array()`, which passed `IS_INDIRECT` slots to `dc_copy_value()` unresolved, so the payload retained pointers into the source object. Once a Randomizer that did not outlive its payload was released, `deepclone_from_array()` dereferenced freed memory and crashed:

```php
$d = deepclone_to_array(new Random\Randomizer(new Random\Engine\Mt19937(42)));
gc_collect_cycles();
deepclone_from_array($d); // SIGSEGV on PHP 8.2
```

This is what segfaults the symfony/polyfill 1.x CI on the PHP 8.2 jobs that install this extension via PIE (the polyfill-only jobs are fixed by the companion PR below); the released v0.7.1 is affected, so those CI legs stay red until this ships in a tagged release.

The fix resolves indirects (and skips resolved UNDEF slots) at the start of the `dc_copy_array()` walk, exactly like the native serializer and the extension's existing `build_scoped_props` loop already do. Verified against a stock PHP 8.2 build: the new `deepclone_randomizer.phpt` segfaults before the fix and passes after; the full suite is green on 8.2 and 8.6, and the polyfill test suite passes against the patched extension.

Companion polyfill fix: symfony/polyfill#632