### PR TITLE
Cover hydrating mangled keys that all resolve to the object's own scope

### DIFF
--- a/tests/deepclone_hydrate.phpt
+++ b/tests/deepclone_hydrate.phpt
@@ -106,6 +106,13 @@ $actual = (array) deepclone_hydrate('Bar', [
 ksort($actual);
 var_dump($actual === $expected);
 
+// Same round trip with every mangled key resolving to the object's own class
+// scope, with no parent-scoped key to hint that the keys need re-keying.
+$src = new Foo();
+(function () { $this->prot = 345; $this->priv = 123; })->call($src);
+$vars = (array) $src;
+var_dump((array) deepclone_hydrate('Foo', $vars) === $vars);
+
 // Exception trace (internal class hydration)
 $e = deepclone_hydrate('Exception', ['trace' => [234]]);
 var_dump($e->getTrace() === [234]);
@@ -313,6 +320,7 @@ var_dump($o instanceof stdClass);
 echo "Done\n";
 ?>
 --EXPECT--
+bool(true)
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
Regression insurance mirroring symfony/polyfill#643, which fixes a `deepclone_hydrate()` bug in the polyfill: hydrating `(array) $obj` failed with `Error: Cannot access property starting with "\0"` whenever *every* mangled key resolved to the object's own class scope, e.g.

```php
class Foo { protected $prot; private $priv; }

deepclone_hydrate(Foo::class, (array) new Foo());
```

The extension is not affected: it resolves each key to its (scope, real name) individually, so there is no path that writes a mangled key verbatim. But the existing round trip here hydrates `Bar`, whose array cast includes the parent-scoped `"\0Foo\0priv"`, and that one key is enough to make an implementation re-key the whole array, masking whether the own-scope keys would have been handled on their own. The polyfill's mirror test had the same blind spot, which is why the bug shipped.

This adds the isolated case: a class whose every mangled key resolves to itself, which is what `(array) $obj` yields for any class declaring only its own protected and private properties.

Test-only, no behavior change. Verified green against PHP 8.4 and 8.5 (41/41 and 48/48).